### PR TITLE
Add tabbed UI with checkpoint estimation

### DIFF
--- a/app/javascript/controllers/checkpoints_controller.js
+++ b/app/javascript/controllers/checkpoints_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list", "template", "output"]
+
+  addRow() {
+    const fragment = this.templateTarget.content.cloneNode(true)
+    this.listTarget.appendChild(fragment)
+  }
+
+  compute() {
+    const rows = this.listTarget.querySelectorAll('.checkpoint-row')
+    const results = []
+    rows.forEach(row => {
+      const name = row.querySelector('[data-field="name"]').value
+      const km = parseFloat(row.querySelector('[data-field="km"]').value)
+      if (!name || isNaN(km)) return
+      const sec = window.timeForDistance ? window.timeForDistance(km) : 0
+      const startSec = sec - 300
+      const endSec = sec + 300
+      const startStr = window.dayTimeString ? window.dayTimeString(startSec) : ''
+      const endStr = window.dayTimeString ? window.dayTimeString(endSec) : ''
+      results.push(`<li>${name}: ${startStr} - ${endStr}</li>`)
+    })
+    this.outputTarget.innerHTML = `<ul class='list-disc pl-5 space-y-1'>${results.join('')}</ul>`
+  }
+}

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel", "tab"]
+
+  connect() {
+    this.show(0)
+  }
+
+  switch(event) {
+    event.preventDefault()
+    const idx = this.tabTargets.indexOf(event.currentTarget)
+    this.show(idx)
+  }
+
+  show(index) {
+    this.tabTargets.forEach((t, i) => {
+      t.classList.toggle('border-blue-500', i === index)
+      t.classList.toggle('text-blue-600', i === index)
+      t.classList.toggle('border-b-2', i === index)
+    })
+    this.panelTargets.forEach((p, i) => {
+      p.classList.toggle('hidden', i !== index)
+    })
+  }
+}

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -1,7 +1,16 @@
-<div class="container mx-auto p-4 space-y-6" data-controller="analysis">
+<div class="container mx-auto p-4 space-y-6" data-controller="analysis tabs">
   <h1 class="text-2xl font-bold">Panel de Carrera</h1>
 
-  <div class="grid gap-6 md:grid-cols-2">
+  <nav class="border-b mb-4 flex space-x-4">
+    <button data-tabs-target="tab" data-action="tabs#switch" class="px-3 py-2 text-sm font-medium border-b-2 border-blue-500 text-blue-600">Datos</button>
+    <button data-tabs-target="tab" data-action="tabs#switch" class="px-3 py-2 text-sm font-medium border-b-2 border-transparent">Perfil</button>
+    <% if @estimated_time %>
+      <button data-tabs-target="tab" data-action="tabs#switch" class="px-3 py-2 text-sm font-medium border-b-2 border-transparent">Puntos de control</button>
+    <% end %>
+  </nav>
+
+  <div data-tabs-target="panel">
+    <div class="grid gap-6 md:grid-cols-2">
     <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg">
       <h2 class="text-xl font-semibold mb-2">Atleta en Strava</h2>
       <% if @athlete.present? %>
@@ -56,9 +65,11 @@
       </div>
     <% end %>
   </div>
+  </div>
 
   <% if @estimated_time %>
-    <div class="grid gap-6 grid-cols-1">
+    <div data-tabs-target="panel" class="hidden">
+      <div class="grid gap-6 grid-cols-1">
       <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg w-full">
         <canvas id="profileChart" class="w-full h-56"></canvas>
       </div>
@@ -84,6 +95,7 @@
         </table>
       </div>
     </div>
+    </div>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const data = {
@@ -100,6 +112,7 @@
           }]
         };
         const kmSeconds = <%= raw(@km_seconds.to_json) %>;
+        window.kmSeconds = kmSeconds;
 
         function timeForDistance(d) {
           if (kmSeconds.length === 0) return 0;
@@ -132,6 +145,9 @@
           const m = Math.floor((seconds % 3600) / 60);
           return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}`;
         }
+
+        window.timeForDistance = timeForDistance;
+        window.dayTimeString = dayTimeString;
 
         new Chart(document.getElementById('profileChart'), {
           type: 'line',
@@ -182,6 +198,21 @@
         input.addEventListener('change', renderTimes);
       });
     </script>
+    <div data-tabs-target="panel" class="hidden" data-controller="checkpoints">
+      <p class="mb-2">Agrega puntos de control para conocer tu hora de paso.</p>
+      <template data-checkpoints-target="template">
+        <div class="checkpoint-row flex space-x-2 mb-2">
+          <input type="text" placeholder="Nombre" data-field="name" class="border rounded p-1 flex-1" />
+          <input type="number" step="0.1" placeholder="Km" data-field="km" class="border rounded p-1 w-24" />
+        </div>
+      </template>
+      <div data-checkpoints-target="list"></div>
+      <div class="mt-2 space-x-2">
+        <button type="button" data-action="checkpoints#addRow" class="px-2 py-1 bg-gray-200 rounded">Añadir punto</button>
+        <button type="button" data-action="checkpoints#compute" class="px-2 py-1 bg-blue-500 text-white rounded">Calcular</button>
+      </div>
+      <div data-checkpoints-target="output" class="mt-4 space-y-1"></div>
+    </div>
   <% elsif flash[:alert] %>
     <p class="text-red-600"><%= flash[:alert] %></p>
   <% end %>


### PR DESCRIPTION
## Summary
- reorganize athlete view into tabs
- add controller for tabs
- add controller for custom checkpoints
- expose functions on window for computing checkpoint times

## Testing
- `bundle exec rails test` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685543a228ec8322bd9e978bec3da0fc