### PR TITLE
Reorganize results view with tabs

### DIFF
--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+
+  connect() {
+    this.show(0)
+  }
+
+  change(event) {
+    event.preventDefault()
+    const index = this.tabTargets.indexOf(event.currentTarget)
+    if (index >= 0) {
+      this.show(index)
+    }
+  }
+
+  show(index) {
+    this.tabTargets.forEach((tab, i) => {
+      if (i === index) {
+        tab.classList.add("border-blue-500", "text-blue-600")
+        tab.classList.remove("border-transparent", "text-gray-500")
+      } else {
+        tab.classList.add("border-transparent", "text-gray-500")
+        tab.classList.remove("border-blue-500", "text-blue-600")
+      }
+    })
+    this.panelTargets.forEach((panel, i) => {
+      panel.classList.toggle("hidden", i !== index)
+    })
+  }
+}

--- a/app/javascript/controllers/time_dial_controller.js
+++ b/app/javascript/controllers/time_dial_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dial", "hourHand", "minuteHand", "input", "label"]
+
+  connect() {
+    this.hour = 0
+    this.minute = 0
+    this.dragging = false
+    this.updateHands()
+    this.labelTarget.textContent = "00:00"
+  }
+
+  pointerDown(event) {
+    event.preventDefault()
+    this.dragging = true
+    this.updateFromEvent(event)
+    this.dialTarget.setPointerCapture(event.pointerId)
+  }
+
+  pointerMove(event) {
+    if (!this.dragging) return
+    this.updateFromEvent(event)
+  }
+
+  pointerUp(event) {
+    if (!this.dragging) return
+    this.dragging = false
+    this.dialTarget.releasePointerCapture(event.pointerId)
+  }
+
+  updateFromEvent(event) {
+    const rect = this.dialTarget.getBoundingClientRect()
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    const angle = Math.atan2(event.clientY - cy, event.clientX - cx) * 180 / Math.PI + 90
+    const deg = (angle + 360) % 360
+    this.hour = Math.floor(deg / 15) % 24
+    this.minute = Math.round((deg % 15) * 4)
+    if (this.minute === 60) {
+      this.minute = 0
+      this.hour = (this.hour + 1) % 24
+    }
+    this.update()
+  }
+
+  update() {
+    this.updateHands()
+    const value = `${String(this.hour).padStart(2,'0')}:${String(this.minute).padStart(2,'0')}`
+    this.inputTarget.value = value
+    this.labelTarget.textContent = value
+    this.inputTarget.dispatchEvent(new Event('change'))
+  }
+
+  updateHands() {
+    const hourDeg = this.hour * 15 + this.minute * 0.25
+    const minuteDeg = this.minute * 6
+    this.hourHandTarget.style.transform = `translate(-50%, -100%) rotate(${hourDeg}deg)`
+    this.minuteHandTarget.style.transform = `translate(-50%, -100%) rotate(${minuteDeg}deg)`
+  }
+}

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -79,9 +79,16 @@
         </div>
         <div data-tabs-target="panel" class="hidden">
           <h2 class="text-xl font-semibold mb-2">Progreso por hora</h2>
-          <div class="flex items-center space-x-2 mb-4">
+          <div class="flex items-center space-x-4 mb-4" data-controller="time-dial">
             <label for="startTime" class="font-medium">Hora de inicio:</label>
-            <input type="time" id="startTime" class="border rounded p-2 bg-white shadow-inner">
+            <input type="time" id="startTime" data-time-dial-target="input" class="hidden">
+            <div data-time-dial-target="dial"
+                 class="relative w-24 h-24 rounded-full border-2 border-blue-500 bg-white"
+                 data-action="pointerdown->time-dial#pointerDown pointermove->time-dial#pointerMove pointerup->time-dial#pointerUp pointerleave->time-dial#pointerUp">
+              <div data-time-dial-target="hourHand" class="absolute left-1/2 top-1/2 w-0.5 bg-blue-700 origin-bottom" style="height:30%;"></div>
+              <div data-time-dial-target="minuteHand" class="absolute left-1/2 top-1/2 w-0.5 bg-blue-400 origin-bottom" style="height:45%;"></div>
+            </div>
+            <span data-time-dial-target="label" class="text-blue-700 font-medium">00:00</span>
           </div>
           <table class="w-full text-left mb-4">
             <thead>

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -27,11 +27,45 @@
           <h2 class="text-xl font-semibold mb-2">Calcula tu tiempo estimado</h2>
         <% end %>
         <% if @estimated_time %>
-          <p class="text-lg font-medium mb-2">Tiempo estimado:</p>
-          <p class="text-4xl font-bold mb-1"><%= @estimated_time %></p>
-          <p class="text-sm text-gray-600 mb-4">
-            <%= @total_distance %> km &bull; <%= @total_elevation %> m+
-          </p>
+          <div data-controller="tabs">
+            <nav class="border-b border-gray-200 mb-4">
+              <ul class="flex space-x-4">
+                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Resumen</button></li>
+                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Gráfica</button></li>
+                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Progreso</button></li>
+              </ul>
+            </nav>
+            <div data-tabs-target="panel">
+              <p class="text-lg font-medium mb-2">Tiempo estimado:</p>
+              <p class="text-4xl font-bold mb-1"><%= @estimated_time %></p>
+              <p class="text-sm text-gray-600 mb-4">
+                <%= @total_distance %> km &bull; <%= @total_elevation %> m+
+              </p>
+            </div>
+            <div data-tabs-target="panel" class="hidden">
+              <canvas id="profileChart" class="w-full h-56"></canvas>
+            </div>
+            <div data-tabs-target="panel" class="hidden">
+              <h2 class="text-xl font-semibold mb-2">Progreso por hora</h2>
+              <div class="flex items-center space-x-2 mb-4">
+                <label for="startTime" class="font-medium">Hora de inicio:</label>
+                <input type="time" id="startTime" class="border rounded p-2 bg-white shadow-inner">
+              </div>
+              <table class="w-full text-left mb-4">
+                <thead>
+                  <tr>
+                    <th class="px-2 py-1">Hora</th>
+                    <th class="px-2 py-1">Dist. acum. (km)</th>
+                    <th class="px-2 py-1">Km tramo</th>
+                    <th class="px-2 py-1">Desnivel +</th>
+                    <th class="px-2 py-1">Desnivel -</th>
+                    <th class="px-2 py-1">Hora del día</th>
+                  </tr>
+                </thead>
+                <tbody id="hourTimes"></tbody>
+              </table>
+            </div>
+          </div>
         <% else %>
           <%= form_with url: athlete_path(@athlete.id), method: :post, data: { action: 'submit->analysis#submit', turbo: false, analysis_target: 'form' }, local: true, multipart: true do %>
             <div data-analysis-target="dropzone"
@@ -58,32 +92,6 @@
   </div>
 
   <% if @estimated_time %>
-    <div class="grid gap-6 grid-cols-1">
-      <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg w-full">
-        <canvas id="profileChart" class="w-full h-56"></canvas>
-      </div>
-
-      <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg w-full">
-        <h2 class="text-xl font-semibold mb-2">Progreso por hora</h2>
-        <div class="flex items-center space-x-2 mb-4">
-          <label for="startTime" class="font-medium">Hora de inicio:</label>
-          <input type="time" id="startTime" class="border rounded p-2 bg-white shadow-inner">
-        </div>
-        <table class="w-full text-left mb-4">
-          <thead>
-            <tr>
-              <th class="px-2 py-1">Hora</th>
-              <th class="px-2 py-1">Dist. acum. (km)</th>
-              <th class="px-2 py-1">Km tramo</th>
-              <th class="px-2 py-1">Desnivel +</th>
-              <th class="px-2 py-1">Desnivel -</th>
-              <th class="px-2 py-1">Hora del día</th>
-            </tr>
-          </thead>
-          <tbody id="hourTimes"></tbody>
-        </table>
-      </div>
-    </div>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const data = {

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -27,45 +27,11 @@
           <h2 class="text-xl font-semibold mb-2">Calcula tu tiempo estimado</h2>
         <% end %>
         <% if @estimated_time %>
-          <div data-controller="tabs">
-            <nav class="border-b border-gray-200 mb-4">
-              <ul class="flex space-x-4">
-                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Resumen</button></li>
-                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Gráfica</button></li>
-                <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Progreso</button></li>
-              </ul>
-            </nav>
-            <div data-tabs-target="panel">
-              <p class="text-lg font-medium mb-2">Tiempo estimado:</p>
-              <p class="text-4xl font-bold mb-1"><%= @estimated_time %></p>
-              <p class="text-sm text-gray-600 mb-4">
-                <%= @total_distance %> km &bull; <%= @total_elevation %> m+
-              </p>
-            </div>
-            <div data-tabs-target="panel" class="hidden">
-              <canvas id="profileChart" class="w-full h-56"></canvas>
-            </div>
-            <div data-tabs-target="panel" class="hidden">
-              <h2 class="text-xl font-semibold mb-2">Progreso por hora</h2>
-              <div class="flex items-center space-x-2 mb-4">
-                <label for="startTime" class="font-medium">Hora de inicio:</label>
-                <input type="time" id="startTime" class="border rounded p-2 bg-white shadow-inner">
-              </div>
-              <table class="w-full text-left mb-4">
-                <thead>
-                  <tr>
-                    <th class="px-2 py-1">Hora</th>
-                    <th class="px-2 py-1">Dist. acum. (km)</th>
-                    <th class="px-2 py-1">Km tramo</th>
-                    <th class="px-2 py-1">Desnivel +</th>
-                    <th class="px-2 py-1">Desnivel -</th>
-                    <th class="px-2 py-1">Hora del día</th>
-                  </tr>
-                </thead>
-                <tbody id="hourTimes"></tbody>
-              </table>
-            </div>
-          </div>
+          <p class="text-lg font-medium mb-2">Tiempo estimado:</p>
+          <p class="text-4xl font-bold mb-1"><%= @estimated_time %></p>
+          <p class="text-sm text-gray-600 mb-4">
+            <%= @total_distance %> km &bull; <%= @total_elevation %> m+
+          </p>
         <% else %>
           <%= form_with url: athlete_path(@athlete.id), method: :post, data: { action: 'submit->analysis#submit', turbo: false, analysis_target: 'form' }, local: true, multipart: true do %>
             <div data-analysis-target="dropzone"
@@ -92,6 +58,48 @@
   </div>
 
   <% if @estimated_time %>
+    <div class="grid gap-6 grid-cols-1">
+      <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg w-full" data-controller="tabs">
+        <nav class="border-b border-gray-200 mb-4">
+          <ul class="flex space-x-4">
+            <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Resumen</button></li>
+            <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Gráfica</button></li>
+            <li><button class="px-3 py-2 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="tabs#change">Progreso</button></li>
+          </ul>
+        </nav>
+        <div data-tabs-target="panel">
+          <p class="text-lg font-medium mb-2">Tiempo estimado:</p>
+          <p class="text-4xl font-bold mb-1"><%= @estimated_time %></p>
+          <p class="text-sm text-gray-600 mb-4">
+            <%= @total_distance %> km &bull; <%= @total_elevation %> m+
+          </p>
+        </div>
+        <div data-tabs-target="panel" class="hidden">
+          <canvas id="profileChart" class="w-full h-56"></canvas>
+        </div>
+        <div data-tabs-target="panel" class="hidden">
+          <h2 class="text-xl font-semibold mb-2">Progreso por hora</h2>
+          <div class="flex items-center space-x-2 mb-4">
+            <label for="startTime" class="font-medium">Hora de inicio:</label>
+            <input type="time" id="startTime" class="border rounded p-2 bg-white shadow-inner">
+          </div>
+          <table class="w-full text-left mb-4">
+            <thead>
+              <tr>
+                <th class="px-2 py-1">Hora</th>
+                <th class="px-2 py-1">Dist. acum. (km)</th>
+                <th class="px-2 py-1">Km tramo</th>
+                <th class="px-2 py-1">Desnivel +</th>
+                <th class="px-2 py-1">Desnivel -</th>
+                <th class="px-2 py-1">Hora del día</th>
+              </tr>
+            </thead>
+            <tbody id="hourTimes"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const data = {


### PR DESCRIPTION
## Summary
- organize athlete results into tabbed sections
- add stimulus controller for tabs

## Testing
- `bin/rails test` *(fails: rbenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855508f81bc8322b4043f8abdd97ee8