### PR TITLE
Add nutrition PDF download option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "prawn"
 
 # Access the Strava API via https://github.com/dblock/strava-ruby-client
 gem "strava-ruby-client"

--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -25,6 +25,11 @@ class AthletesController < ApplicationController
     end
   end
 
+  def nutrition
+    plan = NutritionPlan.new(start_time: params[:start_time])
+    send_data plan.pdf, filename: "plan_nutricional.pdf", type: "application/pdf"
+  end
+
   private
 
   def fetch_athlete(id = nil)

--- a/app/services/nutrition_plan.rb
+++ b/app/services/nutrition_plan.rb
@@ -1,0 +1,66 @@
+class NutritionPlan
+  Block = Struct.new(:group, :section, :hours, :mix, :mix_ch, :gel, :gel_ch, keyword_init: true)
+
+  BLOCKS = [
+    Block.new(group: "Bloque 1", section: nil, hours: 7, mix: "1/2 Drink Mix 320", mix_ch: 40, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 2", section: "A", hours: 4, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 2", section: "B", hours: 3, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 100", gel_ch: 25),
+    Block.new(group: "Bloque 3", section: "A", hours: 2, mix: "1/2 Drink Mix 320", mix_ch: 40, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 3", section: "B", hours: 2, mix: "1/2 Drink Mix 320", mix_ch: 40, gel: "Gel 100 CAF", gel_ch: 25),
+    Block.new(group: "Bloque 3", section: "C", hours: 3, mix: "1/2 Drink Mix 320", mix_ch: 40, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 4", section: "A", hours: 1, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 100 CAF", gel_ch: 25),
+    Block.new(group: "Bloque 4", section: "B", hours: 1, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 4", section: "C", hours: 2, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 100", gel_ch: 25),
+    Block.new(group: "Bloque 4", section: "D", hours: 1, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 160", gel_ch: 40),
+    Block.new(group: "Bloque 4", section: "E", hours: 2, mix: "1/2 Drink Mix 160", mix_ch: 20, gel: "Gel 100", gel_ch: 25)
+  ]
+
+  def initialize(start_time: "08:00", hours: 30)
+    @start_time = start_time.presence || "08:00"
+    @max_hours = hours
+  end
+
+  def lines
+    schedule.map do |info|
+      s = day_time(info[:start])
+      e = day_time(info[:start] + info[:hours])
+      "BLQ #{info[:name].sub('Bloque ', '')} (#{s}–#{e}) - #{info[:mix]} #{info[:mix_ch]} g CH - #{info[:gel]} #{info[:gel_ch]} g CH"
+    end
+  end
+
+  def pdf
+    require "prawn"
+    Prawn::Document.new(page_size: 'A4') do |pdf|
+      lines.each { |l| pdf.text(l) }
+    end.render
+  end
+
+  private
+
+  def schedule
+    return @schedule if @schedule
+    @schedule = []
+    count = 0
+    BLOCKS.each do |b|
+      limit = [b.hours, @max_hours - count].min
+      break if limit <= 0
+      @schedule << { name: [b.group, b.section].compact.join(' '), start: count, hours: limit, mix: b.mix, mix_ch: b.mix_ch, gel: b.gel, gel_ch: b.gel_ch }
+      count += limit
+    end
+    last = BLOCKS.last
+    while count < @max_hours
+      if @schedule.empty? || @schedule.last[:name] != [last.group, last.section].compact.join(' ')
+        @schedule << { name: [last.group, last.section].compact.join(' '), start: count, hours: 0, mix: last.mix, mix_ch: last.mix_ch, gel: last.gel, gel_ch: last.gel_ch }
+      end
+      @schedule.last[:hours] += 1
+      count += 1
+    end
+    @schedule
+  end
+
+  def day_time(hour_offset)
+    h, m = @start_time.split(":").map(&:to_i)
+    t = Time.new(2000, 1, 1, h, m) + hour_offset.hours
+    t.strftime("%H:%M")
+  end
+end

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -128,7 +128,10 @@
           </table>
         </div>
         <div data-tabs-target="panel" class="hidden" data-controller="nutrition">
-          <h2 class="text-xl font-semibold mb-2">Plan nutricional</h2>
+          <h2 class="text-xl font-semibold mb-2 flex items-center space-x-4">
+            <span>Plan nutricional</span>
+            <%= link_to 'Descargar PDF', nutrition_athlete_path(@athlete, format: :pdf, start_time: @start_time), class: 'text-blue-500 underline' %>
+          </h2>
           <details class="mb-4">
             <summary class="cursor-pointer font-semibold">Resumen</summary>
             <ul class="list-disc pl-6 text-sm mt-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   root "home#index"
   resources :athletes, only: [:show]
+  get "athletes/:id/nutrition" => "athletes#nutrition", as: :nutrition_athlete, defaults: { format: :pdf }
   post "athletes/:id" => "athletes#show"
 
   get "/auth/strava" => "sessions#connect", as: :strava_connect


### PR DESCRIPTION
## Summary
- generate nutrition plan on server side using new `NutritionPlan` service
- allow athletes to download plan as PDF via `nutrition` route
- show a download link in the nutrition tab
- add Prawn gem for PDF rendering

## Testing
- `bundle exec rails test` *(fails: rbenv: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855d628946c8322b7a78bd5d4e3264d