### PR TITLE
Display split time for checkpoints

### DIFF
--- a/app/javascript/controllers/checkpoints_controller.js
+++ b/app/javascript/controllers/checkpoints_controller.js
@@ -6,20 +6,37 @@ export default class extends Controller {
   static values = { kmSeconds: Array }
   static targets = ["name", "km", "list"]
 
+  connect() {
+    this.points = []
+  }
+
   add(event) {
     event.preventDefault()
     const name = this.nameTarget.value.trim()
     const km = parseFloat(this.kmTarget.value)
     if (!name || isNaN(km)) return
     const secs = this.timeForDistance(km)
-    const time = this.timeRangeString(secs)
-    const tr = document.createElement("tr")
-    tr.innerHTML = `<td class='px-2 py-1'>${name}</td>` +
-      `<td class='px-2 py-1'>${km}</td>` +
-      `<td class='px-2 py-1'>${time}</td>`
-    this.listTarget.appendChild(tr)
+    this.points.push({ name, km, secs })
+    this.points.sort((a, b) => a.km - b.km)
+    this.render()
     this.nameTarget.value = ""
     this.kmTarget.value = ""
+  }
+
+  render() {
+    this.listTarget.innerHTML = ""
+    let prev = 0
+    this.points.forEach(pt => {
+      const range = this.timeRangeString(pt.secs)
+      const diff = this.formatTime(pt.secs - prev)
+      const tr = document.createElement("tr")
+      tr.innerHTML = `<td class='px-2 py-1'>${pt.name}</td>` +
+        `<td class='px-2 py-1'>${pt.km}</td>` +
+        `<td class='px-2 py-1'>${range}</td>` +
+        `<td class='px-2 py-1'>${diff}</td>`
+      this.listTarget.appendChild(tr)
+      prev = pt.secs
+    })
   }
 
   timeForDistance(d) {

--- a/app/javascript/controllers/nutrition_controller.js
+++ b/app/javascript/controllers/nutrition_controller.js
@@ -107,7 +107,9 @@ export default class extends Controller {
         const end = new Date(base.getTime() + (block.start + block.hours) * 3600 * 1000)
         const secSummary = document.createElement("summary")
         secSummary.classList.add("cursor-pointer", "font-medium", "bg-gray-100", "px-2", "py-1", "rounded")
-        secSummary.textContent = `${block.name} (${timeStr(start)}–${timeStr(end)}) (${block.mixCH + block.gelCH}g)`
+        const relStart = this.formatTime(block.start * 3600)
+        const relEnd = this.formatTime((block.start + block.hours) * 3600)
+        secSummary.textContent = `${block.name} (${timeStr(start)}–${timeStr(end)}) [${relStart} - ${relEnd}](${block.mixCH + block.gelCH}g)`
         section.appendChild(secSummary)
 
         const table = document.createElement("table")
@@ -145,5 +147,11 @@ export default class extends Controller {
       })
       this.listTarget.appendChild(groupDetail)
     })
+  }
+
+  formatTime(seconds) {
+    const h = Math.floor(seconds / 3600)
+    const m = Math.floor((seconds % 3600) / 60)
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`
   }
 }

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -122,6 +122,7 @@
                 <th class="px-2 py-1">Nombre</th>
                 <th class="px-2 py-1">Km</th>
                 <th class="px-2 py-1">Rango aprox.</th>
+                <th class="px-2 py-1">Tiempo desde último</th>
               </tr>
             </thead>
             <tbody data-checkpoints-target="list"></tbody>


### PR DESCRIPTION
## Summary
- show new column 'Tiempo desde último' in Controles tab
- compute time difference from the previous checkpoint in Stimulus controller
- include elapsed time range in nutrition plan summaries

## Testing
- ❌ `bundle exec rails test` (failed to run because Ruby 3.2.2 is missing)


------
https://chatgpt.com/codex/tasks/task_e_685609b5855883229ec0897f93c21f49