### PR TITLE
Add Cancancan and settings configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "jbuilder"
 
 # Access the Strava API via https://github.com/dblock/strava-ruby-client
 gem "strava-ruby-client"
+gem "cancancan"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,20 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  # Only allow modern browsers supporting webp images, web push, badges, importmaps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  rescue_from CanCan::AccessDenied do
+    redirect_to root_path, alert: 'No autorizado'
+  end
+
+  helper_method :current_athlete_id
+
+  private
+
+  def current_athlete_id
+    session[:athlete_id]
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_athlete_id)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,15 +6,19 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: 'No autorizado'
   end
 
-  helper_method :current_athlete_id
+  helper_method :current_user, :current_athlete_id
 
   private
 
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
   def current_athlete_id
-    session[:athlete_id]
+    current_user&.profile&.athlete_id
   end
 
   def current_ability
-    @current_ability ||= Ability.new(current_athlete_id)
+    @current_ability ||= Ability.new(current_user)
   end
 end

--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -30,7 +30,7 @@ class AthletesController < ApplicationController
   def fetch_athlete(id = nil)
     token = session[:strava_token] || ENV['STRAVA_ACCESS_TOKEN']
     client = StravaClient.new(access_token: token)
-    if id.present? && session[:athlete_id].present? && id.to_s != session[:athlete_id].to_s
+    if id.present? && current_athlete_id.present? && id.to_s != current_athlete_id.to_s
       client.athlete(id)
     else
       client.athlete

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
-    if session[:strava_token] && session[:athlete_id]
-      redirect_to athlete_path(session[:athlete_id]) and return
+    if session[:strava_token] && current_athlete_id
+      redirect_to athlete_path(current_athlete_id) and return
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,9 +35,19 @@ class SessionsController < ApplicationController
       client_secret: client_secret
     )
     token = client.oauth_token(code: params[:code])
+    athlete_id = token.athlete['id']
+
+    profile = Profile.find_by(athlete_id: athlete_id)
+    user = profile&.user
+    unless user
+      user = User.create!
+      user.create_profile!(athlete_id: athlete_id)
+    end
+
+    session[:user_id] = user.id
     session[:strava_token] = token.access_token
-    session[:athlete_id] = token.athlete['id']
-    redirect_to athlete_path(token.athlete['id'])
+
+    redirect_to athlete_path(athlete_id)
   rescue StandardError
     redirect_to root_path, alert: 'No se pudo autenticar con Strava'
   end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,14 +3,14 @@ class SettingsController < ApplicationController
 
   def show
     authorize! :manage, :settings
-    @features = session[:features] || { race_predictor: true }
+    @race_predictor = current_user.permissions.find_or_initialize_by(name: 'race_predictor')
   end
 
   def update
     authorize! :manage, :settings
-    session[:features] = {
-      race_predictor: params[:race_predictor] == '1'
-    }
+    perm = current_user.permissions.find_or_initialize_by(name: 'race_predictor')
+    perm.enabled = params[:race_predictor] == '1'
+    perm.save!
     redirect_to settings_path, notice: 'Configuraci\u00f3n actualizada'
   end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -17,6 +17,6 @@ class SettingsController < ApplicationController
   private
 
   def authenticate_user
-    redirect_to root_path unless session[:athlete_id]
+    redirect_to root_path unless session[:user_id]
   end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,22 @@
+class SettingsController < ApplicationController
+  before_action :authenticate_user
+
+  def show
+    authorize! :manage, :settings
+    @features = session[:features] || { race_predictor: true }
+  end
+
+  def update
+    authorize! :manage, :settings
+    session[:features] = {
+      race_predictor: params[:race_predictor] == '1'
+    }
+    redirect_to settings_path, notice: 'Configuraci\u00f3n actualizada'
+  end
+
+  private
+
+  def authenticate_user
+    redirect_to root_path unless session[:athlete_id]
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,12 +2,23 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    admin_ids = ENV.fetch('ADMIN_IDS', '').split(',')
-    athlete_id = user&.profile&.athlete_id
-    if athlete_id && admin_ids.include?(athlete_id.to_s)
+    user ||= User.new
+
+    can :read, :all
+
+    if user.admin?
       can :manage, :all
-    else
-      can :read, :all
+    end
+
+    user.permissions.each do |perm|
+      next unless perm.enabled?
+
+      case perm.name
+      when 'manage_settings'
+        can :manage, :settings
+      when 'race_predictor'
+        can :use, :race_predictor
+      end
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,12 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(athlete_id)
+    admin_ids = ENV.fetch('ADMIN_IDS', '').split(',')
+    if admin_ids.include?(athlete_id.to_s)
+      can :manage, :all
+    else
+      can :read, :all
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,9 +1,10 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(athlete_id)
+  def initialize(user)
     admin_ids = ENV.fetch('ADMIN_IDS', '').split(',')
-    if admin_ids.include?(athlete_id.to_s)
+    athlete_id = user&.profile&.athlete_id
+    if athlete_id && admin_ids.include?(athlete_id.to_s)
       can :manage, :all
     else
       can :read, :all

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,5 @@
+class Permission < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_one :profile, dependent: :destroy
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ApplicationRecord
   has_one :profile, dependent: :destroy
+  has_many :permissions, dependent: :destroy
+
+  def permission_enabled?(name)
+    permissions.find_by(name: name)&.enabled?
+  end
 end

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -22,6 +22,7 @@
     </div>
 
     <% if @athlete.present? %>
+      <% if session.dig(:features, :race_predictor) != false %>
       <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg">
         <% unless @estimated_time %>
           <h2 data-analysis-target="heading" class="text-xl font-semibold mb-2">Cargar Archivo</h2>
@@ -64,6 +65,11 @@
 
         <% end %>
       </div>
+      <% else %>
+      <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg">
+        <p class="text-gray-600">El predictor de carrera está deshabilitado.</p>
+      </div>
+      <% end %>
       <% end %>
     </div>
 

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -22,7 +22,7 @@
     </div>
 
     <% if @athlete.present? %>
-      <% if session.dig(:features, :race_predictor) != false %>
+      <% if can? :use, :race_predictor %>
       <div class="bg-white/80 backdrop-blur-md rounded-xl p-6 shadow-lg">
         <% unless @estimated_time %>
           <h2 data-analysis-target="heading" class="text-xl font-semibold mb-2">Cargar Archivo</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,9 @@
     <nav class="bg-white shadow-md">
       <div class="container mx-auto px-4 py-3 flex justify-between items-center">
         <%= link_to 'Trepando Cerros', root_path, class: 'font-semibold text-lg' %>
+        <% if can? :manage, :settings %>
+          <%= link_to 'Configuraci\u00f3n', settings_path, class: 'text-sm ml-4 text-blue-600' %>
+        <% end %>
       </div>
     </nav>
     <%= yield %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -2,7 +2,7 @@
 <%= form_with url: settings_path, method: :patch do %>
   <div class="mb-4">
     <label class="flex items-center">
-      <%= check_box_tag :race_predictor, '1', @features[:race_predictor] %>
+      <%= check_box_tag :race_predictor, '1', @race_predictor.enabled? %>
       <span class="ml-2">Habilitar predictor de carrera</span>
     </label>
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,10 @@
+<h1 class="text-2xl font-bold mb-4">Configuraci\u00f3n</h1>
+<%= form_with url: settings_path, method: :patch do %>
+  <div class="mb-4">
+    <label class="flex items-center">
+      <%= check_box_tag :race_predictor, '1', @features[:race_predictor] %>
+      <span class="ml-2">Habilitar predictor de carrera</span>
+    </label>
+  </div>
+  <%= submit_tag 'Guardar', class: 'px-4 py-2 bg-blue-600 text-white rounded' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   get "/auth/strava" => "sessions#connect", as: :strava_connect
   get "/auth/strava/callback" => "sessions#callback", as: :strava_callback
   delete "/logout" => "sessions#destroy", as: :logout
+  resource :settings, only: [:show, :update]
 end

--- a/db/migrate/20250627023000_create_users_and_profiles.rb
+++ b/db/migrate/20250627023000_create_users_and_profiles.rb
@@ -1,0 +1,14 @@
+class CreateUsersAndProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.boolean :admin, default: false
+      t.timestamps
+    end
+
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :athlete_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250627024000_create_permissions.rb
+++ b/db/migrate/20250627024000_create_permissions.rb
@@ -1,0 +1,11 @@
+class CreatePermissions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :permissions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.boolean :enabled, default: true
+      t.timestamps
+    end
+    add_index :permissions, [:user_id, :name], unique: true
+  end
+end


### PR DESCRIPTION
## Summary
- add `cancancan` gem
- add `Ability` model
- add `SettingsController` and simple feature toggle view
- show configuration link when authorized
- wrap race predictor UI with settings
- expose current ability in ApplicationController
- register settings resource

## Testing
- `bundle exec rake test` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859ecd674308322ad2d000c3f5c7c77