### PR TITLE
Añadir dashboard con tooltip y menú de perfil

### DIFF
--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -1,5 +1,10 @@
 <div class="container mx-auto p-4 space-y-6" data-controller="analysis">
-  <h1 class="text-2xl font-bold">Panel de Carrera</h1>
+  <h1 class="text-3xl font-bold flex items-center gap-2">
+    <div class="tooltip" data-tip="Predictor de carrera">
+      <i class="fa-solid fa-person-running text-primary"></i>
+    </div>
+    <span>Dashboard</span>
+  </h1>
 
   <div class="grid gap-6 md:grid-cols-2">
     <div class="card bg-base-100 shadow">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,12 +38,29 @@
             <span>Trepando Cerros</span>
           <% end %>
         </div>
-        <% if can? :manage, :settings %>
+        <% if current_user %>
           <div class="flex-none">
-            <%= link_to settings_path, class: 'btn btn-sm flex items-center gap-1' do %>
-              <i class="fa-solid fa-gear fa-lg text-primary"></i>
-              <span>Configuración</span>
-            <% end %>
+            <div class="dropdown dropdown-end">
+              <label tabindex="0" class="btn btn-ghost">
+                <i class="fa-solid fa-user"></i>
+              </label>
+              <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-40">
+                <li>
+                  <%= link_to athlete_path(current_athlete_id), class: 'flex items-center gap-2' do %>
+                    <i class="fa-solid fa-user"></i>
+                    <span>Perfil</span>
+                  <% end %>
+                </li>
+                <% if can? :manage, :settings %>
+                  <li>
+                    <%= link_to settings_path, class: 'flex items-center gap-2' do %>
+                      <i class="fa-solid fa-gear"></i>
+                      <span>Configuración</span>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary
- add a dashboard header with an icon tooltip
- move profile and config links to a dropdown menu in the navbar

## Testing
- `bin/rubocop -A`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_685e12411138832290dddf1c20e7a1f1