### PR TITLE
Add admin account and restrict settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Además considera el desgaste del cuerpo: a medida que se acumulan kilómetros s
   La interfaz muestra tarjetas con efecto de vidrio y un pequeño botón gris de **Cerrar sesión** en la esquina inferior derecha cuando estás autenticado. El área de carga admite arrastrar y soltar el GPX y muestra mensajes animados durante el análisis. Una vez calculado el resultado se muestra el **tiempo estimado**. Si seleccionas una hora de inicio verás una tabla con la distancia acumulada por hora, los kilómetros recorridos en cada tramo y el desnivel positivo y negativo por hora. La última fila indica la hora estimada de finalización. Encima de la tabla se muestra la gráfica de elevación y, al pasar el cursor, indica la hora aproximada de paso según la hora de inicio.
 
 Esta aplicación usa Tailwind CSS junto con la librería daisyUI, cargada desde CDN y aplicando el tema **nord** para un estilo coherente y moderno. Toda la interfaz se apoya en componentes de daisyUI para botones, formularios y tablas.
+
+## Perfil de administrador
+
+La primera cuenta que se crea en la aplicación se marca como administradora. Solo este usuario puede acceder a la sección de configuración. Los demás usuarios únicamente verán las opciones de predicción de carreras.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,8 @@ class SessionsController < ApplicationController
     profile = Profile.find_by(athlete_id: athlete_id)
     user = profile&.user
     unless user
-      user = User.create!
+      admin_flag = User.count.zero?
+      user = User.create!(admin: admin_flag)
       user.create_profile!(athlete_id: athlete_id)
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,16 +6,12 @@ class Ability
 
     can :read, :all
 
-    if user.admin?
-      can :manage, :all
-    end
+    can :manage, :all if user.admin?
 
     user.permissions.each do |perm|
       next unless perm.enabled?
 
       case perm.name
-      when 'manage_settings'
-        can :manage, :settings
       when 'race_predictor'
         can :use, :race_predictor
       end


### PR DESCRIPTION
## Summary
- create an admin account automatically when the first user signs in
- remove `manage_settings` permission from regular users
- document the admin profile behavior

## Testing
- `bundle exec rubocop` *(fails: version `3.2.2` is not installed)*
- `bin/rails test` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e216010c4832292c535cf5f392eb0