### PR TITLE
Enable per-user permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ Esta aplicación usa Tailwind CSS junto con la librería daisyUI, cargada desde 
 
 ## Perfil de administrador
 
-La primera cuenta que se crea en la aplicación se marca como administradora. Solo este usuario puede acceder a la sección de configuración. Los demás usuarios únicamente verán las opciones de predicción de carreras.
+Las cuentas ya no se crean con permisos de administrador por defecto. Cualquier usuario inicia con un perfil normal y puede gestionar sus propios permisos desde la sección de configuración.
+
+Cada perfil puede habilitar o deshabilitar funciones como el predictor de carrera de forma independiente.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Esta aplicación usa Tailwind CSS junto con la librería daisyUI, cargada desde 
 
 ## Perfil de administrador
 
-Las cuentas ya no se crean con permisos de administrador por defecto. Cualquier usuario inicia con un perfil normal y puede gestionar sus propios permisos desde la sección de configuración.
+Las cuentas ya no se crean con permisos de administrador por defecto. Cualquier usuario inicia con un perfil **normal**, creado automáticamente al iniciar el proyecto. Desde la sección de configuración se puede ver la lista completa de perfiles y ajustar sus permisos.
 
 Cada perfil puede habilitar o deshabilitar funciones como el predictor de carrera de forma independiente.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Esta aplicación usa Tailwind CSS junto con la librería daisyUI, cargada desde 
 Las cuentas ya no se crean con permisos de administrador por defecto. Cualquier usuario inicia con un perfil **normal**, creado automáticamente al iniciar el proyecto. Desde la sección de configuración se puede ver la lista completa de perfiles y ajustar sus permisos.
 
 Cada perfil puede habilitar o deshabilitar funciones como el predictor de carrera de forma independiente.
+Desde la lista de perfiles puedes ingresar a cada uno y cambiar sus permisos usando botones de tipo switch que muestran claramente si una opción está encendida o apagada.

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -4,6 +4,9 @@ class RolesController < ApplicationController
   def show
     authorize! :manage, :settings
     @permissions = available_permissions
+    return unless turbo_frame_request?
+
+    render partial: 'roles/permissions_form', locals: { role: @role, permissions: @permissions }
   end
 
   def update
@@ -13,7 +16,12 @@ class RolesController < ApplicationController
       perm.enabled = params[name] == '1'
       perm.save!
     end
-    redirect_to role_path(@role), notice: 'Perfil actualizado'
+    @permissions = available_permissions
+    if turbo_frame_request?
+      render partial: 'roles/permissions_form', locals: { role: @role, permissions: @permissions }
+    else
+      redirect_to role_path(@role), notice: 'Perfil actualizado'
+    end
   end
 
   private

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,0 +1,28 @@
+class RolesController < ApplicationController
+  before_action :set_role
+
+  def show
+    authorize! :manage, :settings
+    @permissions = available_permissions
+  end
+
+  def update
+    authorize! :manage, :settings
+    available_permissions.each do |name|
+      perm = @role.role_permissions.find_or_initialize_by(name: name)
+      perm.enabled = params[name] == '1'
+      perm.save!
+    end
+    redirect_to role_path(@role), notice: 'Perfil actualizado'
+  end
+
+  private
+
+  def set_role
+    @role = Role.find(params[:id])
+  end
+
+  def available_permissions
+    %w[race_predictor]
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,8 @@ class SessionsController < ApplicationController
     profile = Profile.find_by(athlete_id: athlete_id)
     user = profile&.user
     unless user
-      user = User.create!
+      default_role = Role.find_by(name: 'normal')
+      user = User.create!(role: default_role)
       user.create_profile!(athlete_id: athlete_id)
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,8 +40,7 @@ class SessionsController < ApplicationController
     profile = Profile.find_by(athlete_id: athlete_id)
     user = profile&.user
     unless user
-      admin_flag = User.count.zero?
-      user = User.create!(admin: admin_flag)
+      user = User.create!
       user.create_profile!(athlete_id: athlete_id)
     end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -5,6 +5,7 @@ class SettingsController < ApplicationController
   def show
     authorize! :manage, :settings
     @race_predictor = current_user.permissions.find_or_initialize_by(name: 'race_predictor')
+    @roles = Role.all
   end
 
   def update

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,8 @@ class Ability
     can :manage, :settings if user.persisted?
     can :manage, :all if user.role&.admin?
 
-    user.permissions.each do |perm|
+    role_perms = user.role ? user.role.role_permissions : []
+    (role_perms + user.permissions).each do |perm|
       next unless perm.enabled?
 
       case perm.name

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
 
     can :read, :all
 
+    can :manage, :settings if user.persisted?
     can :manage, :all if user.admin?
 
     user.permissions.each do |perm|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
     can :read, :all
 
     can :manage, :settings if user.persisted?
-    can :manage, :all if user.admin?
+    can :manage, :all if user.role&.admin?
 
     user.permissions.each do |perm|
       next unless perm.enabled?

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,3 @@
+class Role < ApplicationRecord
+  has_many :users, dependent: :nullify
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,8 @@
 class Role < ApplicationRecord
   has_many :users, dependent: :nullify
+  has_many :role_permissions, dependent: :destroy
+
+  def admin?
+    name == 'admin'
+  end
 end

--- a/app/models/role_permission.rb
+++ b/app/models/role_permission.rb
@@ -1,0 +1,4 @@
+class RolePermission < ApplicationRecord
+  belongs_to :role
+  validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  belongs_to :role, optional: true
   has_one :profile, dependent: :destroy
   has_many :permissions, dependent: :destroy
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,11 +40,11 @@
         </div>
         <% if current_user %>
           <div class="flex-none">
-            <div class="dropdown dropdown-end z-50">
-              <label tabindex="0" class="btn btn-ghost">
+            <details class="dropdown dropdown-end z-50">
+              <summary class="btn btn-ghost">
                 <i class="fa-solid fa-user"></i>
-              </label>
-              <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-40 z-50">
+              </summary>
+              <ul class="menu dropdown-content bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm">
                 <li>
                   <label for="profile-modal" class="flex items-center gap-2 cursor-pointer">
                     <i class="fa-solid fa-user"></i>
@@ -58,7 +58,7 @@
                   <% end %>
                 </li>
               </ul>
-            </div>
+            </details>
           </div>
         <% end %>
       </div>

--- a/app/views/roles/_list.html.erb
+++ b/app/views/roles/_list.html.erb
@@ -1,0 +1,18 @@
+<ul class="list bg-base-100 rounded-box shadow-md w-full">
+  <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">Perfiles registrados</li>
+  <% roles.each do |role| %>
+    <li class="list-row">
+      <div><img class="size-10 rounded-box" src="https://img.daisyui.com/images/profile/demo/1@94.webp" /></div>
+      <div class="list-col-grow">
+        <div class="capitalize"><%= role.name %></div>
+      </div>
+      <%= link_to role_path(role), class: 'btn btn-square btn-ghost', data: { turbo_frame: 'roles' } do %>
+        <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
+            <path d="M6 3L20 12 6 21 6 3z"></path>
+          </g>
+        </svg>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/roles/_permissions_form.html.erb
+++ b/app/views/roles/_permissions_form.html.erb
@@ -1,0 +1,15 @@
+<h3 class="font-semibold mb-2 capitalize"><%= role.name %></h3>
+<%= form_with model: role, url: role_path(role), method: :patch, data: { turbo_frame: 'roles' } do %>
+  <div class="space-y-4">
+    <% permissions.each do |perm| %>
+      <% record = role.role_permissions.find_by(name: perm) %>
+      <div class="form-control">
+        <div class="flex items-center justify-between">
+          <span class="label-text capitalize"><%= perm.tr('_', ' ') %></span>
+          <%= check_box_tag perm, '1', record&.enabled?, class: 'toggle border-indigo-600 bg-indigo-500 checked:border-orange-500 checked:bg-orange-400 checked:text-orange-800' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <button type="submit" class="btn btn-primary mt-4">Guardar</button>
+<% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,0 +1,18 @@
+<div class="container mx-auto p-4 space-y-6">
+  <h2 class="text-xl font-semibold"><%= @role.name.capitalize %></h2>
+
+  <%= form_with model: @role, url: role_path(@role), method: :patch do %>
+    <div class="space-y-4">
+      <% @permissions.each do |perm| %>
+        <% record = @role.role_permissions.find_by(name: perm) %>
+        <div class="form-control">
+          <label class="label cursor-pointer justify-start space-x-2">
+            <%= check_box_tag perm, '1', record&.enabled?, class: 'toggle border-gray-400 bg-gray-300 checked:border-primary checked:bg-primary checked:text-primary-content' %>
+            <span class="label-text capitalize"><%= perm.tr('_', ' ') %></span>
+          </label>
+        </div>
+      <% end %>
+    </div>
+    <button type="submit" class="btn btn-primary mt-4">Guardar</button>
+  <% end %>
+</div>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,18 +1,7 @@
-<div class="container mx-auto p-4 space-y-6">
-  <h2 class="text-xl font-semibold"><%= @role.name.capitalize %></h2>
-
-  <%= form_with model: @role, url: role_path(@role), method: :patch do %>
-    <div class="space-y-4">
-      <% @permissions.each do |perm| %>
-        <% record = @role.role_permissions.find_by(name: perm) %>
-        <div class="form-control">
-          <div class="flex items-center justify-between">
-            <span class="label-text capitalize"><%= perm.tr('_', ' ') %></span>
-            <%= check_box_tag perm, '1', record&.enabled?, class: 'toggle toggle-primary' %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-    <button type="submit" class="btn btn-primary mt-4">Guardar</button>
-  <% end %>
-</div>
+<% unless turbo_frame_request? %>
+  <div class="container mx-auto p-4 space-y-6">
+<% end %>
+  <%= render 'permissions_form', role: @role, permissions: @permissions %>
+<% unless turbo_frame_request? %>
+  </div>
+<% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -8,18 +8,7 @@
         <div class="form-control">
           <div class="flex items-center justify-between">
             <span class="label-text capitalize"><%= perm.tr('_', ' ') %></span>
-            <label class="toggle text-base-content">
-              <%= check_box_tag perm, '1', record&.enabled? %>
-              <svg aria-label="enabled" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <g stroke-linejoin="round" stroke-linecap="round" stroke-width="4" fill="none" stroke="currentColor">
-                  <path d="M20 6 9 17l-5-5"></path>
-                </g>
-              </svg>
-              <svg aria-label="disabled" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 6 6 18" />
-                <path d="m6 6 12 12" />
-              </svg>
-            </label>
+            <%= check_box_tag perm, '1', record&.enabled?, class: 'toggle toggle-primary' %>
           </div>
         </div>
       <% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -6,10 +6,21 @@
       <% @permissions.each do |perm| %>
         <% record = @role.role_permissions.find_by(name: perm) %>
         <div class="form-control">
-          <label class="label cursor-pointer justify-start space-x-2">
-            <%= check_box_tag perm, '1', record&.enabled?, class: 'toggle border-gray-400 bg-gray-300 checked:border-primary checked:bg-primary checked:text-primary-content' %>
+          <div class="flex items-center justify-between">
             <span class="label-text capitalize"><%= perm.tr('_', ' ') %></span>
-          </label>
+            <label class="toggle text-base-content">
+              <%= check_box_tag perm, '1', record&.enabled? %>
+              <svg aria-label="enabled" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <g stroke-linejoin="round" stroke-linecap="round" stroke-width="4" fill="none" stroke="currentColor">
+                  <path d="M20 6 9 17l-5-5"></path>
+                </g>
+              </svg>
+              <svg aria-label="disabled" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </label>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -37,10 +37,25 @@
         <div data-tabs-target="panel" class="hidden space-y-4">
           <div>
             <h3 class="font-semibold mb-2">Perfiles disponibles</h3>
-            <ul class="list-disc list-inside">
-              <% @roles.each do |role| %>
-                <li>
-                  <%= link_to role.name, role_path(role), class: 'link' %>
+            <ul class="list bg-base-100 rounded-box shadow-md">
+              <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">
+                Perfiles registrados
+              </li>
+              <% @roles.each_with_index do |role, idx| %>
+                <li class="list-row">
+                  <div class="text-4xl font-thin opacity-30 tabular-nums">
+                    <%= '%02d' % (idx + 1) %>
+                  </div>
+                  <div class="list-col-grow">
+                    <div class="capitalize"><%= role.name %></div>
+                  </div>
+                  <%= link_to role_path(role), class: 'btn btn-square btn-ghost' do %>
+                    <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
+                        <path d="M6 3L20 12 6 21 6 3z"></path>
+                      </g>
+                    </svg>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -39,7 +39,9 @@
             <h3 class="font-semibold mb-2">Perfiles disponibles</h3>
             <ul class="list-disc list-inside">
               <% @roles.each do |role| %>
-                <li><%= role.name %></li>
+                <li>
+                  <%= link_to role.name, role_path(role), class: 'link' %>
+                </li>
               <% end %>
             </ul>
           </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -37,41 +37,10 @@
         <div data-tabs-target="panel" class="hidden space-y-4">
           <div>
             <h3 class="font-semibold mb-2">Perfiles disponibles</h3>
-            <ul class="list bg-base-100 rounded-box shadow-md">
-              <li class="p-4 pb-2 text-xs opacity-60 tracking-wide">
-                Perfiles registrados
-              </li>
-              <% @roles.each_with_index do |role, idx| %>
-                <li class="list-row">
-                  <div class="text-4xl font-thin opacity-30 tabular-nums">
-                    <%= '%02d' % (idx + 1) %>
-                  </div>
-                  <div class="list-col-grow">
-                    <div class="capitalize"><%= role.name %></div>
-                  </div>
-                  <%= link_to role_path(role), class: 'btn btn-square btn-ghost' do %>
-                    <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                      <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2" fill="none" stroke="currentColor">
-                        <path d="M6 3L20 12 6 21 6 3z"></path>
-                      </g>
-                    </svg>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
+            <turbo-frame id="roles">
+              <%= render 'roles/list', roles: @roles %>
+            </turbo-frame>
           </div>
-          <%= form_with url: athlete_settings_path(@athlete&.id), method: :patch do %>
-            <div class="form-control mb-4">
-              <label class="label cursor-pointer">
-                <%= check_box_tag :race_predictor, '1', @race_predictor.enabled?, class: 'checkbox' %>
-                <span class="label-text ml-2">Habilitar predictor de carrera</span>
-              </label>
-            </div>
-            <button type="submit" class="btn btn-primary flex items-center gap-1">
-              <i class="fa-solid fa-floppy-disk text-primary"></i>
-              <span>Guardar</span>
-            </button>
-          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -34,7 +34,15 @@
         <div data-tabs-target="panel">
           <p class="text-gray-600">Configuraciones generales.</p>
         </div>
-        <div data-tabs-target="panel" class="hidden">
+        <div data-tabs-target="panel" class="hidden space-y-4">
+          <div>
+            <h3 class="font-semibold mb-2">Perfiles disponibles</h3>
+            <ul class="list-disc list-inside">
+              <% @roles.each do |role| %>
+                <li><%= role.name %></li>
+              <% end %>
+            </ul>
+          </div>
           <%= form_with url: athlete_settings_path(@athlete&.id), method: :patch do %>
             <div class="form-control mb-4">
               <label class="label cursor-pointer">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :athletes, only: [:show] do
     resource :settings, only: [:show, :update]
   end
+  resources :roles, only: [:show, :update]
   post "athletes/:id" => "athletes#show"
 
   get "/auth/strava" => "sessions#connect", as: :strava_connect

--- a/db/migrate/20250627025500_create_roles.rb
+++ b/db/migrate/20250627025500_create_roles.rb
@@ -1,0 +1,10 @@
+class CreateRoles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :roles do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_reference :users, :role, foreign_key: true
+  end
+end

--- a/db/migrate/20250627030500_create_role_permissions.rb
+++ b/db/migrate/20250627030500_create_role_permissions.rb
@@ -1,0 +1,11 @@
+class CreateRolePermissions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :role_permissions do |t|
+      t.references :role, null: false, foreign_key: true
+      t.string :name, null: false
+      t.boolean :enabled, default: true
+      t.timestamps
+    end
+    add_index :role_permissions, [:role_id, :name], unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,5 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+Role.find_or_create_by!(name: 'normal')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,4 +8,5 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-Role.find_or_create_by!(name: 'normal')
+role = Role.find_or_create_by!(name: 'normal')
+RolePermission.find_or_create_by!(role: role, name: 'race_predictor')


### PR DESCRIPTION
## Summary
- disable automatic admin assignment when creating the first account
- allow any logged in user to manage the Settings section
- update docs to explain that every account starts as normal

## Testing
- `bundle exec rake test` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e26c20dd88322b94b579e03d19da3