### PR TITLE
Add training section with calendar view

### DIFF
--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -3,6 +3,8 @@ class TrainingsController < ApplicationController
   before_action :set_athlete
 
   def show
+    @week_start = Date.current.beginning_of_week
+    @messages = random_messages(7)
   end
 
   private
@@ -25,5 +27,20 @@ class TrainingsController < ApplicationController
     end
   rescue StandardError
     nil
+  end
+
+  def random_messages(count)
+    samples = [
+      "Sesión de fuerza y resistencia.",
+      "Rodaje suave por la ciudad.",
+      "Entrenamiento de velocidad en pista.",
+      "Día de descanso y estiramientos.",
+      "Trabajos de técnica de carrera.",
+      "Entrenamiento cruzado con bicicleta.",
+      "Series en subida de intensidad moderada.",
+      "Sesión de recuperación activa.",
+      "Rodaje por terreno montañoso." 
+    ]
+    samples.shuffle.take(count)
   end
 end

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -1,0 +1,29 @@
+class TrainingsController < ApplicationController
+  before_action :authenticate_user
+  before_action :set_athlete
+
+  def show
+  end
+
+  private
+
+  def authenticate_user
+    redirect_to root_path unless session[:user_id]
+  end
+
+  def set_athlete
+    @athlete = fetch_athlete(params[:athlete_id])
+  end
+
+  def fetch_athlete(id = nil)
+    token = session[:strava_token] || ENV['STRAVA_ACCESS_TOKEN']
+    client = StravaClient.new(access_token: token)
+    if id.present? && current_athlete_id.present? && id.to_s != current_athlete_id.to_s
+      client.athlete(id)
+    else
+      client.athlete
+    end
+  rescue StandardError
+    nil
+  end
+end

--- a/app/javascript/controllers/training_calendar_controller.js
+++ b/app/javascript/controllers/training_calendar_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["day", "collapse"]
+  static values = { initialIndex: Number }
+
+  connect() {
+    this.selectedIndex = this.initialIndexValue || 0
+    this.update()
+  }
+
+  select(event) {
+    event.preventDefault()
+    const index = parseInt(event.currentTarget.dataset.trainingCalendarIndexValue, 10)
+    if (!isNaN(index)) {
+      this.selectedIndex = index
+      this.update()
+    }
+  }
+
+  update() {
+    this.dayTargets.forEach((day, i) => {
+      if (i === this.selectedIndex) {
+        day.classList.add("bg-primary", "text-primary-content")
+      } else {
+        day.classList.remove("bg-primary", "text-primary-content")
+      }
+    })
+    this.collapseTargets.forEach((collapse, i) => {
+      const input = collapse.querySelector("input[type='checkbox']")
+      if (input) input.checked = i === this.selectedIndex
+    })
+  }
+}

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -7,6 +7,12 @@
           <span>Dashboard</span>
         <% end %>
       </li>
+      <li>
+        <%= link_to athlete_training_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
+        <% end %>
+      </li>
       <% if can? :manage, :settings %>
         <li>
           <%= link_to athlete_settings_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -7,6 +7,12 @@
           <span>Dashboard</span>
         <% end %>
       </li>
+      <li>
+        <%= link_to athlete_training_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
+        <% end %>
+      </li>
       <% if can? :manage, :settings %>
         <li>
           <%= link_to athlete_settings_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -24,72 +24,32 @@
     </ul>
   </aside>
 
-  <div class="flex-1 space-y-6">
+  <div class="flex-1 space-y-6" data-controller="training-calendar" data-training-calendar-initial-index="<%= (Date.current - @week_start).to_i %>">
     <div class="card bg-base-100 card-border border-base-300 card-sm overflow-hidden">
       <div class="card-body gap-4">
-        <div class="border-b-base-300 grid grid-cols-7 border-b border-dashed pb-3">
-          <% start_of_week = Date.current.beginning_of_week %>
+        <div class="border-b-base-300 grid grid-cols-7 border-b border-dashed pb-3" data-training-calendar-target="dayContainer">
           <% (0..6).each do |i| %>
-            <% day = start_of_week + i.days %>
-            <div class="rounded-field flex flex-col items-center px-2 py-1 <%= 'bg-primary text-primary-content' if day == Date.current %>">
+            <% day = @week_start + i.days %>
+            <div class="rounded-field flex flex-col items-center px-2 py-1" data-training-calendar-target="day" data-training-calendar-index-value="<%= i %>" data-action="click->training-calendar#select">
               <span class="text-sm font-semibold"><%= day.day %></span>
               <span class="text-[10px] font-semibold opacity-50"><%= day.strftime('%a')[0] %></span>
             </div>
           <% end %>
         </div>
-        <div>
-          <label class="input input-sm input-border flex w-auto items-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
-              <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd"></path>
-            </svg>
-            <input type="text" placeholder="Search for events">
-          </label>
-        </div>
-        <div class="flex flex-col gap-2">
-          <label class="flex cursor-pointer items-center gap-2">
-            <input type="checkbox" class="toggle toggle-sm toggle-primary" checked>
-            <span class="text-xs">Show all day events</span>
-          </label>
-        </div>
-      </div>
-      <div class="bg-base-300">
-        <div class="flex items-center gap-2 p-4">
-          <div class="grow">
-            <div class="text-sm font-medium">Team Sync Meeting</div>
-            <div class="text-xs opacity-60">Weekly product review with design and development teams</div>
-          </div>
-          <div class="shrink-0">
-            <span class="badge badge-sm badge-neutral">1h</span>
-          </div>
-        </div>
       </div>
     </div>
 
-    <div class="flex flex-col gap-4">
-      <div class="alert max-sm:alert-vertical alert-info text-xs font-bold">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"></path>
-        </svg>
-        There are 9 new messages
+    <% (0..6).each do |i| %>
+      <% day = @week_start + i.days %>
+      <div class="bg-base-100 border-base-300 collapse border" data-training-calendar-target="collapse">
+        <input type="checkbox" class="peer" <%= 'checked' if i == (Date.current - @week_start).to_i %>>
+        <div class="collapse-title bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
+          <%= l day, format: :long %>
+        </div>
+        <div class="collapse-content bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
+          <%= @messages[i] %>
+        </div>
       </div>
-      <div class="alert alert-outline max-sm:alert-vertical alert-success text-xs font-bold">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z"></path>
-        </svg>
-        Verification process completed
-      </div>
-      <div class="alert alert-dash max-sm:alert-vertical alert-warning text-xs font-bold">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286Zm0 13.036h.008v.008H12v-.008Z"></path>
-        </svg>
-        <span><span class="link">Click</span> to verify your email</span>
-      </div>
-      <div class="alert alert-soft max-sm:alert-vertical alert-error text-xs font-bold">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"></path>
-        </svg>
-        Access denied <button class="btn btn-xs btn-ghost">Support</button>
-      </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -1,0 +1,95 @@
+<div class="container mx-auto p-4 flex gap-6">
+  <aside class="w-48 space-y-2">
+    <ul class="menu bg-base-100 p-2 rounded-box">
+      <li>
+        <%= link_to athlete_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-chart-line"></i>
+          <span>Dashboard</span>
+        <% end %>
+      </li>
+      <li>
+        <%= link_to athlete_training_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
+        <% end %>
+      </li>
+      <% if can? :manage, :settings %>
+        <li>
+          <%= link_to athlete_settings_path(@athlete&.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete&.id)) ? "active" : nil)].compact.join(' ') do %>
+            <i class="fa-solid fa-gear"></i>
+            <span>Configuración</span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </aside>
+
+  <div class="flex-1 space-y-6">
+    <div class="card bg-base-100 card-border border-base-300 card-sm overflow-hidden">
+      <div class="card-body gap-4">
+        <div class="border-b-base-300 grid grid-cols-7 border-b border-dashed pb-3">
+          <% start_of_week = Date.current.beginning_of_week %>
+          <% (0..6).each do |i| %>
+            <% day = start_of_week + i.days %>
+            <div class="rounded-field flex flex-col items-center px-2 py-1 <%= 'bg-primary text-primary-content' if day == Date.current %>">
+              <span class="text-sm font-semibold"><%= day.day %></span>
+              <span class="text-[10px] font-semibold opacity-50"><%= day.strftime('%a')[0] %></span>
+            </div>
+          <% end %>
+        </div>
+        <div>
+          <label class="input input-sm input-border flex w-auto items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+              <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd"></path>
+            </svg>
+            <input type="text" placeholder="Search for events">
+          </label>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label class="flex cursor-pointer items-center gap-2">
+            <input type="checkbox" class="toggle toggle-sm toggle-primary" checked>
+            <span class="text-xs">Show all day events</span>
+          </label>
+        </div>
+      </div>
+      <div class="bg-base-300">
+        <div class="flex items-center gap-2 p-4">
+          <div class="grow">
+            <div class="text-sm font-medium">Team Sync Meeting</div>
+            <div class="text-xs opacity-60">Weekly product review with design and development teams</div>
+          </div>
+          <div class="shrink-0">
+            <span class="badge badge-sm badge-neutral">1h</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-4">
+      <div class="alert max-sm:alert-vertical alert-info text-xs font-bold">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"></path>
+        </svg>
+        There are 9 new messages
+      </div>
+      <div class="alert alert-outline max-sm:alert-vertical alert-success text-xs font-bold">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z"></path>
+        </svg>
+        Verification process completed
+      </div>
+      <div class="alert alert-dash max-sm:alert-vertical alert-warning text-xs font-bold">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286Zm0 13.036h.008v.008H12v-.008Z"></path>
+        </svg>
+        <span><span class="link">Click</span> to verify your email</span>
+      </div>
+      <div class="alert alert-soft max-sm:alert-vertical alert-error text-xs font-bold">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"></path>
+        </svg>
+        Access denied <button class="btn btn-xs btn-ghost">Support</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   root "home#index"
   resources :athletes, only: [:show] do
+    resource :training, only: [:show]
     resource :settings, only: [:show, :update]
   end
   resources :roles, only: [:show, :update]


### PR DESCRIPTION
## Summary
- add `TrainingsController`
- route `/athletes/:athlete_id/training`
- link "Entrenamiento" in athlete sidebar menus
- create training view with weekly calendar card and alert examples

## Testing
- `bin/rubocop` *(fails: rbenv: version `3.2.2` is not installed)*
- `bin/rails test` *(fails: rbenv: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e325c13e483229e6abbb352e5e026