### PR TITLE
Allow training and settings pages without Strava

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -82,8 +82,8 @@ class SessionsController < ApplicationController
 
   def disconnect
     session.delete(:strava_token)
-    if current_athlete_id
-      redirect_to athlete_settings_path(current_athlete_id)
+    if current_user
+      redirect_to settings_path
     else
       redirect_to root_path
     end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -13,7 +13,7 @@ class SettingsController < ApplicationController
     perm = current_user.permissions.find_or_initialize_by(name: 'race_predictor')
     perm.enabled = params[:race_predictor] == '1'
     perm.save!
-    redirect_to athlete_settings_path(@athlete), notice: 'Configuraci\u00f3n actualizada'
+    redirect_to settings_path, notice: 'Configuraci\u00f3n actualizada'
   end
 
   private

--- a/app/views/athletes/show.html.erb
+++ b/app/views/athletes/show.html.erb
@@ -10,33 +10,17 @@
         </li>
       <% end %>
       <li>
-        <% if @athlete.present? %>
-          <%= link_to athlete_training_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          <% end %>
-        <% else %>
-          <span class="flex items-center gap-2 text-gray-500">
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          </span>
+        <%= link_to training_path, class: ["flex items-center gap-2", (current_page?(training_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
         <% end %>
       </li>
-      <% if can? :manage, :settings %>
-        <li>
-          <% if @athlete.present? %>
-            <%= link_to athlete_settings_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            <% end %>
-          <% else %>
-            <span class="flex items-center gap-2 text-gray-500">
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            </span>
-          <% end %>
-        </li>
-      <% end %>
+      <li>
+        <%= link_to settings_path, class: ["flex items-center gap-2", (current_page?(settings_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-gear"></i>
+          <span>Configuración</span>
+        <% end %>
+      </li>
     </ul>
   </aside>
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -10,33 +10,17 @@
         </li>
       <% end %>
       <li>
-        <% if @athlete.present? %>
-          <%= link_to athlete_training_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          <% end %>
-        <% else %>
-          <span class="flex items-center gap-2 text-gray-500">
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          </span>
+        <%= link_to training_path, class: ["flex items-center gap-2", (current_page?(training_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
         <% end %>
       </li>
-      <% if can? :manage, :settings %>
-        <li>
-          <% if @athlete.present? %>
-            <%= link_to athlete_settings_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            <% end %>
-          <% else %>
-            <span class="flex items-center gap-2 text-gray-500">
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            </span>
-          <% end %>
-        </li>
-      <% end %>
+      <li>
+        <%= link_to settings_path, class: ["flex items-center gap-2", (current_page?(settings_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-gear"></i>
+          <span>Configuración</span>
+        <% end %>
+      </li>
     </ul>
   </aside>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -10,33 +10,17 @@
         </li>
       <% end %>
       <li>
-        <% if @athlete.present? %>
-          <%= link_to athlete_training_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          <% end %>
-        <% else %>
-          <span class="flex items-center gap-2 text-gray-500">
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          </span>
+        <%= link_to training_path, class: ["flex items-center gap-2", (current_page?(training_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
         <% end %>
       </li>
-      <% if can? :manage, :settings %>
-        <li>
-          <% if @athlete.present? %>
-            <%= link_to athlete_settings_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            <% end %>
-          <% else %>
-            <span class="flex items-center gap-2 text-gray-500">
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            </span>
-          <% end %>
-        </li>
-      <% end %>
+      <li>
+        <%= link_to settings_path, class: ["flex items-center gap-2", (current_page?(settings_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-gear"></i>
+          <span>Configuración</span>
+        <% end %>
+      </li>
     </ul>
   </aside>
 

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -10,33 +10,17 @@
         </li>
       <% end %>
       <li>
-        <% if @athlete.present? %>
-          <%= link_to athlete_training_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_training_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          <% end %>
-        <% else %>
-          <span class="flex items-center gap-2 text-gray-500">
-            <i class="fa-solid fa-dumbbell"></i>
-            <span>Entrenamiento</span>
-          </span>
+        <%= link_to training_path, class: ["flex items-center gap-2", (current_page?(training_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-dumbbell"></i>
+          <span>Entrenamiento</span>
         <% end %>
       </li>
-      <% if can? :manage, :settings %>
-        <li>
-          <% if @athlete.present? %>
-            <%= link_to athlete_settings_path(@athlete.id), class: ["flex items-center gap-2", (current_page?(athlete_settings_path(@athlete.id)) ? "active" : nil)].compact.join(' ') do %>
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            <% end %>
-          <% else %>
-            <span class="flex items-center gap-2 text-gray-500">
-              <i class="fa-solid fa-gear"></i>
-              <span>Configuración</span>
-            </span>
-          <% end %>
-        </li>
-      <% end %>
+      <li>
+        <%= link_to settings_path, class: ["flex items-center gap-2", (current_page?(settings_path) ? "active" : nil)].compact.join(' ') do %>
+          <i class="fa-solid fa-gear"></i>
+          <span>Configuración</span>
+        <% end %>
+      </li>
     </ul>
   </aside>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "home#index"
+  resource :training, only: [:show]
+  resource :settings, only: [:show, :update]
   resources :athletes, only: [:show] do
     resource :training, only: [:show]
     resource :settings, only: [:show, :update]


### PR DESCRIPTION
## Summary
- expose `/training` and `/settings` routes
- remove restrictions around training and settings links in the sidebar
- update controllers to use new routes

## Testing
- `bundle exec rake test` *(fails: `rbenv: version `3.2.2` is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_687318dbab0c83228201afe1df356520