### PR TITLE
Enable dev auto-login via query param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, importmaps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  before_action :developer_auto_login, if: -> { Rails.env.development? }
+
   rescue_from CanCan::AccessDenied do
     redirect_to root_path, alert: 'No autorizado'
   end
@@ -9,6 +11,13 @@ class ApplicationController < ActionController::Base
   helper_method :current_user, :current_athlete_id
 
   private
+
+  def developer_auto_login
+    return if session[:user_id].present? || params[:auto_login].blank?
+
+    user = User.find_by(email: params[:auto_login])
+    session[:user_id] = user.id if user
+  end
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   private
 
   def developer_auto_login
-    return if session[:user_id].present? || params[:auto_login].blank?
+    return if params[:auto_login].blank?
 
     user = User.find_by(email: params[:auto_login])
     session[:user_id] = user.id if user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,16 @@ class ApplicationController < ActionController::Base
     return if params[:auto_login].blank?
 
     user = User.find_by(email: params[:auto_login])
-    session[:user_id] = user.id if user
+    unless user
+      default_role = Role.find_by(name: 'normal')
+      user = User.create!(
+        email: params[:auto_login],
+        google_id: SecureRandom.uuid,
+        role: default_role
+      )
+    end
+
+    session[:user_id] = user.id
   end
 
   def current_user


### PR DESCRIPTION
## Summary
- allow automatic login by passing `auto_login=<email>` in the query string when running in the development environment

## Testing
- `bundle exec rails test` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687341daf84083228c548e899f07dacd