### PR TITLE
Add activity phase selection for training plan days

### DIFF
--- a/app/controllers/training_plans_controller.rb
+++ b/app/controllers/training_plans_controller.rb
@@ -26,7 +26,11 @@ class TrainingPlansController < ApplicationController
     @training_plan.end_date = @training_plan.start_date.end_of_week(:sunday)
     TrainingPlanDay::DAYS_OF_WEEK.each_index do |i|
       # initialize every day as rest
-      @training_plan.training_plan_days.build(day: i, workout_type: :rest)
+      @training_plan.training_plan_days.build(
+        day: i,
+        workout_type: :rest,
+        activity_phase: :rest
+      )
     end
   end
 
@@ -74,7 +78,7 @@ class TrainingPlansController < ApplicationController
       :start_date,
       :end_date,
       :athlete_id,
-      training_plan_days_attributes: %i[id day workout_type _destroy]
+      training_plan_days_attributes: %i[id day workout_type activity_phase _destroy]
     )
   end
 end

--- a/app/controllers/training_plans_controller.rb
+++ b/app/controllers/training_plans_controller.rb
@@ -24,15 +24,13 @@ class TrainingPlansController < ApplicationController
     end
     @training_plan.start_date = Date.current.beginning_of_week(:monday)
     @training_plan.end_date = @training_plan.start_date.end_of_week(:sunday)
-    TrainingPlanDay::DAYS_OF_WEEK.each_index do |i|
-      # initialize every day as rest
-      @training_plan.training_plan_days.build(
-        day: i,
-        workout_type: :rest,
-        activity_phase: :rest
-      )
-      @training_plan.training_plan_days[i].segments.build(phase: :warm_up)
-    end
+      TrainingPlanDay::DAYS_OF_WEEK.each_index do |i|
+        # initialize every day as rest
+        @training_plan.training_plan_days.build(
+          day: i,
+          workout_type: :rest
+        )
+      end
   end
 
   def create
@@ -79,14 +77,15 @@ class TrainingPlansController < ApplicationController
       :start_date,
       :end_date,
       :athlete_id,
-      training_plan_days_attributes: [
-        :id,
-        :day,
-        :workout_type,
-        :activity_phase,
-        :_destroy,
-        segments_attributes: %i[id phase duration distance hr_zone position _destroy]
-      ]
-    )
+        training_plan_days_attributes: [
+          :id,
+          :day,
+          :workout_type,
+          :_destroy,
+          segments_attributes: %i[
+            id phase objective_type duration distance hr_zone intensity_type intensity_from intensity_to position _destroy
+          ]
+        ]
+      )
+    end
   end
-end

--- a/app/controllers/training_plans_controller.rb
+++ b/app/controllers/training_plans_controller.rb
@@ -31,6 +31,7 @@ class TrainingPlansController < ApplicationController
         workout_type: :rest,
         activity_phase: :rest
       )
+      @training_plan.training_plan_days[i].segments.build(phase: :warm_up)
     end
   end
 
@@ -78,7 +79,14 @@ class TrainingPlansController < ApplicationController
       :start_date,
       :end_date,
       :athlete_id,
-      training_plan_days_attributes: %i[id day workout_type activity_phase _destroy]
+      training_plan_days_attributes: [
+        :id,
+        :day,
+        :workout_type,
+        :activity_phase,
+        :_destroy,
+        segments_attributes: %i[id phase duration distance hr_zone position _destroy]
+      ]
     )
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,20 +1,22 @@
 module ApplicationHelper
   MONTHS_ES_ABBR = %w[Ene Feb Mar Abr May Jun Jul Ago Sep Oct Nov Dic].freeze
-  WORKOUT_COLOR_CLASSES = {
-    'rest' => 'bg-[#A3BE8C] hover:bg-[#8CA877] text-white',
-    'easy_run' => 'bg-[#8FBCBB] hover:bg-[#7aa9a8] text-white',
-    'long_run' => 'bg-[#5E81AC] hover:bg-[#4c6b90] text-white',
-    'intensity' => 'bg-[#BF616A] hover:bg-[#a04c54] text-white',
-    'strength' => 'bg-[#D08770] hover:bg-[#b36f5d] text-white'
-  }.freeze
+    WORKOUT_COLOR_CLASSES = {
+      'rest' => 'bg-[#A3BE8C] hover:bg-[#8CA877] text-white',
+      'easy_run' => 'bg-[#8FBCBB] hover:bg-[#7aa9a8] text-white',
+      'long_run' => 'bg-[#5E81AC] hover:bg-[#4c6b90] text-white',
+      'intensity' => 'bg-[#BF616A] hover:bg-[#a04c54] text-white',
+      'strength' => 'bg-[#D08770] hover:bg-[#b36f5d] text-white',
+      'cross_training' => 'bg-[#EBCB8B] hover:bg-[#d4b473] text-white'
+    }.freeze
 
-  WORKOUT_BORDER_CLASSES = {
-    'rest' => 'border-[#A3BE8C]',
-    'easy_run' => 'border-[#8FBCBB]',
-    'long_run' => 'border-[#5E81AC]',
-    'intensity' => 'border-[#BF616A]',
-    'strength' => 'border-[#D08770]'
-  }.freeze
+    WORKOUT_BORDER_CLASSES = {
+      'rest' => 'border-[#A3BE8C]',
+      'easy_run' => 'border-[#8FBCBB]',
+      'long_run' => 'border-[#5E81AC]',
+      'intensity' => 'border-[#BF616A]',
+      'strength' => 'border-[#D08770]',
+      'cross_training' => 'border-[#EBCB8B]'
+    }.freeze
 
   def workout_color_class(type)
     WORKOUT_COLOR_CLASSES[type.to_s] || ''

--- a/app/javascript/controllers/segments_controller.js
+++ b/app/javascript/controllers/segments_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list", "template", "display"]
+
+  addPhase(event) {
+    event.preventDefault()
+    const phase = event.currentTarget.dataset.phaseValue
+    this.add({ phase })
+  }
+
+  add(detail = {}) {
+    const content = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, Date.now())
+    const fragment = document.createRange().createContextualFragment(content)
+    const item = fragment.firstElementChild
+    if (detail.phase) {
+      const select = item.querySelector("select[name*='[phase]']")
+      if (select) select.value = detail.phase
+    }
+    this.listTarget.appendChild(item)
+    this.updateDisplay()
+  }
+
+  remove(event) {
+    event.preventDefault()
+    const item = event.currentTarget.closest("[data-segment-item]")
+    if (!item) return
+    const destroy = item.querySelector("input[name*='[_destroy]']")
+    if (destroy) destroy.value = 1
+    item.remove()
+    this.updateDisplay()
+  }
+
+  connect() {
+    this.updateDisplay()
+  }
+
+  updateDisplay() {
+    if (!this.hasDisplayTarget) return
+    const texts = Array.from(
+      this.listTarget.querySelectorAll("select[name*='[phase]'] option:checked")
+    ).map(o => o.textContent.trim())
+    this.displayTarget.textContent = texts.join(', ')
+  }
+}

--- a/app/javascript/controllers/segments_controller.js
+++ b/app/javascript/controllers/segments_controller.js
@@ -3,20 +3,11 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["list", "template", "display"]
 
-  addPhase(event) {
+  add(event) {
     event.preventDefault()
-    const phase = event.currentTarget.dataset.phaseValue
-    this.add({ phase })
-  }
-
-  add(detail = {}) {
     const content = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, Date.now())
     const fragment = document.createRange().createContextualFragment(content)
     const item = fragment.firstElementChild
-    if (detail.phase) {
-      const select = item.querySelector("select[name*='[phase]']")
-      if (select) select.value = detail.phase
-    }
     this.listTarget.appendChild(item)
     this.updateDisplay()
   }
@@ -33,6 +24,12 @@ export default class extends Controller {
 
   connect() {
     this.updateDisplay()
+    this.listTarget
+      .querySelectorAll("select[name*='[objective_type]']")
+      .forEach(select => this.changeObjective({ currentTarget: select }))
+    this.listTarget
+      .querySelectorAll("select[name*='[intensity_type]']")
+      .forEach(select => this.changeIntensity({ currentTarget: select }))
   }
 
   updateDisplay() {
@@ -41,5 +38,20 @@ export default class extends Controller {
       this.listTarget.querySelectorAll("select[name*='[phase]'] option:checked")
     ).map(o => o.textContent.trim())
     this.displayTarget.textContent = texts.join(', ')
+  }
+
+  changeObjective(event) {
+    const item = event.currentTarget.closest("[data-segment-item]")
+    const type = event.currentTarget.value
+    item.querySelector('[data-objective-distance]').classList.toggle('hidden', type !== 'distance')
+    item.querySelector('[data-objective-time]').classList.toggle('hidden', type !== 'time')
+    item.querySelector('[data-objective-hr]').classList.toggle('hidden', type !== 'heart_rate_zone')
+  }
+
+  changeIntensity(event) {
+    const item = event.currentTarget.closest("[data-segment-item]")
+    const type = event.currentTarget.value
+    item.querySelector('[data-intensity-hr]').classList.toggle('hidden', type !== 'heart_rate')
+    item.querySelector('[data-intensity-rpe]').classList.toggle('hidden', type !== 'rpe')
   }
 }

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
     "workoutInput",
     "phaseInput",
     "phaseDisplay",
+    "workoutContainer",
     "phaseContainer",
     "modalTitle",
   ]
@@ -13,9 +14,8 @@ export default class extends Controller {
 
   connect() {
     this.updateAppearance(this.workoutInputTarget.value)
-    if (this.hasPhaseContainerTarget) {
-      this.phaseContainerTarget.classList.add("hidden")
-    }
+    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.add("hidden")
+    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.remove("hidden")
   }
 
   choose(event) {
@@ -25,9 +25,8 @@ export default class extends Controller {
     this.workoutInputTarget.value = value
     this.displayTarget.textContent = text
     this.updateAppearance(value)
-    if (this.hasPhaseContainerTarget) {
-      this.phaseContainerTarget.classList.remove("hidden")
-    }
+    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.remove("hidden")
+    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.add("hidden")
   }
 
   choosePhase(event) {
@@ -39,12 +38,16 @@ export default class extends Controller {
       const toggle = document.getElementById(this.toggleIdValue)
       if (toggle) toggle.checked = false
     }
+    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.remove("hidden")
+    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.add("hidden")
   }
 
   open() {
     if (this.hasModalTitleTarget && this.hasTitleValue) {
       this.modalTitleTarget.textContent = this.titleValue
     }
+    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.remove("hidden")
+    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.add("hidden")
   }
 
   updateAppearance(value) {

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -4,7 +4,6 @@ export default class extends Controller {
   static targets = [
     "display",
     "workoutInput",
-    "phaseInput",
     "phaseDisplay",
     "workoutContainer",
     "phaseContainer",
@@ -20,15 +19,13 @@ export default class extends Controller {
 
   choose(event) {
     event.preventDefault()
-    const { workoutValue: value, workoutText: text } =
-      event.currentTarget.dataset
+    const { workoutValue: value, workoutText: text } = event.currentTarget.dataset
     this.workoutInputTarget.value = value
     this.displayTarget.textContent = text
     this.updateAppearance(value)
     if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.remove("hidden")
     if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.add("hidden")
   }
-
 
   open() {
     if (this.hasModalTitleTarget && this.hasTitleValue) {
@@ -45,6 +42,7 @@ export default class extends Controller {
       long_run: "bg-[#5E81AC] hover:bg-[#4c6b90] text-white",
       intensity: "bg-[#BF616A] hover:bg-[#a04c54] text-white",
       strength: "bg-[#D08770] hover:bg-[#b36f5d] text-white",
+      cross_training: "bg-[#EBCB8B] hover:bg-[#d4b473] text-white",
     }
     this.displayTarget.className = `badge rounded-lg ${classes[value] || ''}`
     this.element.classList.remove(
@@ -58,7 +56,9 @@ export default class extends Controller {
       "hover:bg-[#4c6b90]",
       "hover:bg-[#a04c54]",
       "hover:bg-[#b36f5d]",
-      "text-white"
+      "bg-[#EBCB8B]",
+      "hover:bg-[#d4b473]",
+      "text-white",
     )
     if (classes[value]) {
       this.element.classList.add(...classes[value].split(" "))

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -1,11 +1,23 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["display", "workoutInput", "modalTitle"]
+  static targets = [
+    "display",
+    "workoutInput",
+    "phaseInput",
+    "phaseDisplay",
+    "phaseContainer",
+    "modalTitle",
+  ]
   static values = { toggleId: String, title: String }
 
   connect() {
     this.updateAppearance(this.workoutInputTarget.value)
+    if (this.hasPhaseContainerTarget) {
+      if (this.phaseInputTarget.value) {
+        this.phaseContainerTarget.classList.remove("hidden")
+      }
+    }
   }
 
   choose(event) {
@@ -15,6 +27,20 @@ export default class extends Controller {
     this.workoutInputTarget.value = value
     this.displayTarget.textContent = text
     this.updateAppearance(value)
+    if (this.hasPhaseContainerTarget) {
+      this.phaseContainerTarget.classList.remove("hidden")
+    }
+    if (this.toggleIdValue) {
+      const toggle = document.getElementById(this.toggleIdValue)
+      if (toggle) toggle.checked = false
+    }
+  }
+
+  choosePhase(event) {
+    event.preventDefault()
+    const { phaseValue: value, phaseText: text } = event.currentTarget.dataset
+    if (this.hasPhaseInputTarget) this.phaseInputTarget.value = value
+    if (this.hasPhaseDisplayTarget) this.phaseDisplayTarget.textContent = text
     if (this.toggleIdValue) {
       const toggle = document.getElementById(this.toggleIdValue)
       if (toggle) toggle.checked = false

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -12,9 +12,13 @@ export default class extends Controller {
   static values = { toggleId: String, title: String }
 
   connect() {
-    this.updateAppearance(this.workoutInputTarget.value)
-    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.add("hidden")
-    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.remove("hidden")
+    const value = this.workoutInputTarget.value
+    this.updateAppearance(value)
+    const hasWorkout = value && value.length > 0
+    if (this.hasWorkoutContainerTarget)
+      this.workoutContainerTarget.classList.toggle("hidden", hasWorkout)
+    if (this.hasPhaseContainerTarget)
+      this.phaseContainerTarget.classList.toggle("hidden", !hasWorkout)
   }
 
   choose(event) {

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -29,18 +29,6 @@ export default class extends Controller {
     if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.add("hidden")
   }
 
-  choosePhase(event) {
-    event.preventDefault()
-    const { phaseValue: value, phaseText: text } = event.currentTarget.dataset
-    if (this.hasPhaseInputTarget) this.phaseInputTarget.value = value
-    if (this.hasPhaseDisplayTarget) this.phaseDisplayTarget.textContent = text
-    if (this.toggleIdValue) {
-      const toggle = document.getElementById(this.toggleIdValue)
-      if (toggle) toggle.checked = false
-    }
-    if (this.hasWorkoutContainerTarget) this.workoutContainerTarget.classList.remove("hidden")
-    if (this.hasPhaseContainerTarget) this.phaseContainerTarget.classList.add("hidden")
-  }
 
   open() {
     if (this.hasModalTitleTarget && this.hasTitleValue) {

--- a/app/javascript/controllers/workout_selector_controller.js
+++ b/app/javascript/controllers/workout_selector_controller.js
@@ -14,9 +14,7 @@ export default class extends Controller {
   connect() {
     this.updateAppearance(this.workoutInputTarget.value)
     if (this.hasPhaseContainerTarget) {
-      if (this.phaseInputTarget.value) {
-        this.phaseContainerTarget.classList.remove("hidden")
-      }
+      this.phaseContainerTarget.classList.add("hidden")
     }
   }
 
@@ -29,10 +27,6 @@ export default class extends Controller {
     this.updateAppearance(value)
     if (this.hasPhaseContainerTarget) {
       this.phaseContainerTarget.classList.remove("hidden")
-    }
-    if (this.toggleIdValue) {
-      const toggle = document.getElementById(this.toggleIdValue)
-      if (toggle) toggle.checked = false
     }
   }
 

--- a/app/models/training_plan_day.rb
+++ b/app/models/training_plan_day.rb
@@ -7,17 +7,8 @@ class TrainingPlanDay < ApplicationRecord
          easy_run: 1,
          long_run: 2,
          intensity: 3,
-         rest: 4
-       },
-       prefix: true
-
-  enum :activity_phase,
-       {
-         warm_up: 0,
-         workout: 1,
-         rest: 2,
-         cool_down: 3,
-         interval: 4
+         rest: 4,
+         cross_training: 5
        },
        prefix: true
 
@@ -26,7 +17,6 @@ class TrainingPlanDay < ApplicationRecord
 
   validates :day, inclusion: { in: 0..6 }
   validates :workout_type, presence: true
-  validates :activity_phase, presence: true
 
   DAYS_OF_WEEK = %w[Lunes Martes Miércoles Jueves Viernes Sábado Domingo].freeze
 

--- a/app/models/training_plan_day.rb
+++ b/app/models/training_plan_day.rb
@@ -21,6 +21,9 @@ class TrainingPlanDay < ApplicationRecord
        },
        prefix: true
 
+  has_many :segments, class_name: 'TrainingPlanSegment', dependent: :destroy, inverse_of: :training_plan_day
+  accepts_nested_attributes_for :segments, allow_destroy: true
+
   validates :day, inclusion: { in: 0..6 }
   validates :workout_type, presence: true
   validates :activity_phase, presence: true

--- a/app/models/training_plan_day.rb
+++ b/app/models/training_plan_day.rb
@@ -11,8 +11,19 @@ class TrainingPlanDay < ApplicationRecord
        },
        prefix: true
 
+  enum :activity_phase,
+       {
+         warm_up: 0,
+         workout: 1,
+         rest: 2,
+         cool_down: 3,
+         interval: 4
+       },
+       prefix: true
+
   validates :day, inclusion: { in: 0..6 }
   validates :workout_type, presence: true
+  validates :activity_phase, presence: true
 
   DAYS_OF_WEEK = %w[Lunes Martes Miércoles Jueves Viernes Sábado Domingo].freeze
 

--- a/app/models/training_plan_segment.rb
+++ b/app/models/training_plan_segment.rb
@@ -1,13 +1,15 @@
 class TrainingPlanSegment < ApplicationRecord
   belongs_to :training_plan_day
 
-  enum phase: {
-    warm_up: 0,
-    workout: 1,
-    rest: 2,
-    cool_down: 3,
-    interval: 4
-  }, _prefix: true
+  enum :phase,
+       {
+         warm_up: 0,
+         workout: 1,
+         rest: 2,
+         cool_down: 3,
+         interval: 4
+       },
+       prefix: true
 
   validates :phase, presence: true
 end

--- a/app/models/training_plan_segment.rb
+++ b/app/models/training_plan_segment.rb
@@ -4,6 +4,12 @@ class TrainingPlanSegment < ApplicationRecord
   attribute :phase, :integer
   attribute :objective_type, :integer
   attribute :intensity_type, :integer
+  attribute :duration, :integer
+  attribute :distance, :decimal
+  attribute :hr_zone, :integer
+  attribute :intensity_from, :integer
+  attribute :intensity_to, :integer
+  attribute :position, :integer
 
   enum :phase,
        {

--- a/app/models/training_plan_segment.rb
+++ b/app/models/training_plan_segment.rb
@@ -6,10 +6,26 @@ class TrainingPlanSegment < ApplicationRecord
          warm_up: 0,
          workout: 1,
          rest: 2,
-         cool_down: 3,
-         interval: 4
+         cool_down: 3
+       },
+       prefix: true
+
+  enum :objective_type,
+       {
+         distance: 0,
+         time: 1,
+         heart_rate_zone: 2,
+         free: 3
+       },
+       prefix: true
+
+  enum :intensity_type,
+       {
+         heart_rate: 0,
+         rpe: 1
        },
        prefix: true
 
   validates :phase, presence: true
+  validates :objective_type, presence: true
 end

--- a/app/models/training_plan_segment.rb
+++ b/app/models/training_plan_segment.rb
@@ -1,12 +1,17 @@
 class TrainingPlanSegment < ApplicationRecord
   belongs_to :training_plan_day
 
+  attribute :phase, :integer
+  attribute :objective_type, :integer
+  attribute :intensity_type, :integer
+
   enum :phase,
        {
          warm_up: 0,
          workout: 1,
          rest: 2,
-         cool_down: 3
+         cool_down: 3,
+         interval: 4
        },
        prefix: true
 

--- a/app/models/training_plan_segment.rb
+++ b/app/models/training_plan_segment.rb
@@ -1,0 +1,13 @@
+class TrainingPlanSegment < ApplicationRecord
+  belongs_to :training_plan_day
+
+  enum phase: {
+    warm_up: 0,
+    workout: 1,
+    rest: 2,
+    cool_down: 3,
+    interval: 4
+  }, _prefix: true
+
+  validates :phase, presence: true
+end

--- a/app/views/training_plan_days/_segment_fields.html.erb
+++ b/app/views/training_plan_days/_segment_fields.html.erb
@@ -1,0 +1,9 @@
+<div data-segment-item class="flex gap-2 items-end mb-2">
+  <%= f.select :phase, TrainingPlanSegment.phases.keys.map { |p| [t("activerecord.attributes.training_plan_segment.phases.#{p}"), p] }, {}, class: "select select-bordered" %>
+  <%= f.number_field :duration, placeholder: 'min', class: 'input input-bordered w-20' %>
+  <%= f.number_field :distance, step: 0.1, placeholder: 'km', class: 'input input-bordered w-20' %>
+  <%= f.number_field :hr_zone, placeholder: 'FC', class: 'input input-bordered w-20' %>
+  <button type="button" class="btn btn-sm btn-outline" data-action="segments#remove">🗑</button>
+  <%= f.hidden_field :position %>
+  <%= f.hidden_field :_destroy %>
+</div>

--- a/app/views/training_plan_days/_segment_fields.html.erb
+++ b/app/views/training_plan_days/_segment_fields.html.erb
@@ -1,8 +1,23 @@
-<div data-segment-item class="flex gap-2 items-end mb-2">
+<div data-segment-item class="flex flex-wrap gap-2 items-end mb-2">
   <%= f.select :phase, TrainingPlanSegment.phases.keys.map { |p| [t("activerecord.attributes.training_plan_segment.phases.#{p}"), p] }, {}, class: "select select-bordered" %>
-  <%= f.number_field :duration, placeholder: 'min', class: 'input input-bordered w-20' %>
-  <%= f.number_field :distance, step: 0.1, placeholder: 'km', class: 'input input-bordered w-20' %>
-  <%= f.number_field :hr_zone, placeholder: 'FC', class: 'input input-bordered w-20' %>
+  <%= f.select :objective_type, TrainingPlanSegment.objective_types.keys.map { |o| [t("activerecord.attributes.training_plan_segment.objective_types.#{o}"), o] }, {}, class: "select select-bordered", data: { action: "segments#changeObjective" } %>
+  <div data-objective-distance>
+    <%= f.number_field :distance, step: 0.1, placeholder: 'km', class: 'input input-bordered w-24' %>
+  </div>
+  <div data-objective-time class="hidden">
+    <%= f.number_field :duration, placeholder: 'min', class: 'input input-bordered w-24' %>
+  </div>
+  <div data-objective-hr class="hidden">
+    <%= f.number_field :hr_zone, placeholder: 'Zona', class: 'input input-bordered w-24' %>
+  </div>
+  <%= f.select :intensity_type, TrainingPlanSegment.intensity_types.keys.map { |i| [t("activerecord.attributes.training_plan_segment.intensity_types.#{i}"), i] }, {}, class: "select select-bordered", data: { action: "segments#changeIntensity" } %>
+  <div data-intensity-hr>
+    <%= f.number_field :intensity_from, placeholder: 'FC min', class: 'input input-bordered w-20' %>
+    <%= f.number_field :intensity_to, placeholder: 'FC máx', class: 'input input-bordered w-20' %>
+  </div>
+  <div data-intensity-rpe class="hidden">
+    <%= f.select :intensity_from, (1..10).to_a, {}, class: 'select select-bordered w-24' %>
+  </div>
   <button type="button" class="btn btn-sm btn-outline" data-action="segments#remove">🗑</button>
   <%= f.hidden_field :position %>
   <%= f.hidden_field :_destroy %>

--- a/app/views/training_plans/new.html.erb
+++ b/app/views/training_plans/new.html.erb
@@ -55,7 +55,7 @@
                 <div class="modal-box relative rounded-xl">
                   <label for="<%= modal_id %>" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
                   <h3 class="text-lg font-semibold mb-4" data-workout-selector-target="modalTitle"><%= t('training_plans.select_activity') %></h3>
-                  <div class="flex flex-col gap-2">
+                  <div class="flex flex-col gap-2" data-workout-selector-target="workoutContainer">
                     <% TrainingPlanDay.workout_types.keys.each do |k| %>
                       <% text = t("activerecord.attributes.training_plan_day.workout_types.#{k}") %>
                       <button type="button" class="btn <%= workout_color_class(k) %> rounded-lg" data-action="click->workout-selector#choose" data-workout-value="<%= k %>" data-workout-text="<%= text %>"><%= text %></button>

--- a/app/views/training_plans/new.html.erb
+++ b/app/views/training_plans/new.html.erb
@@ -40,10 +40,14 @@
               <div class="form-control mb-4 rounded-lg p-2 <%= workout_color_class(day_fields.object.workout_type) %>" data-controller="workout-selector" data-workout-selector-toggle-id-value="<%= modal_id %>" data-workout-selector-title-value="<%= t('training_plans.select_activity_for', date: "#{TrainingPlanDay::DAYS_OF_WEEK[day_fields.object.day]} #{short_date_es(date)}") %>">
               <%= day_fields.hidden_field :day %>
               <%= day_fields.hidden_field :workout_type, value: day_fields.object.workout_type, data: { workout_selector_target: 'workoutInput' } %>
+              <%= day_fields.hidden_field :activity_phase, value: day_fields.object.activity_phase, data: { workout_selector_target: 'phaseInput' } %>
               <label for="<%= modal_id %>" class="label cursor-pointer" data-action="click->workout-selector#open">
                 <span class="label-text"><%= "#{TrainingPlanDay::DAYS_OF_WEEK[day_fields.object.day]} #{short_date_es(date)}" %>:</span>
                 <span data-workout-selector-target="display" class="<%= workout_color_class(day_fields.object.workout_type) %> badge rounded-lg">
                   <%= t("activerecord.attributes.training_plan_day.workout_types.#{day_fields.object.workout_type}") %>
+                </span>
+                <span data-workout-selector-target="phaseDisplay" class="badge badge-outline ml-2">
+                  <%= t("activerecord.attributes.training_plan_day.activity_phases.#{day_fields.object.activity_phase}") %>
                 </span>
               </label>
               <input type="checkbox" id="<%= modal_id %>" class="modal-toggle" />
@@ -55,6 +59,12 @@
                     <% TrainingPlanDay.workout_types.keys.each do |k| %>
                       <% text = t("activerecord.attributes.training_plan_day.workout_types.#{k}") %>
                       <button type="button" class="btn <%= workout_color_class(k) %> rounded-lg" data-action="click->workout-selector#choose" data-workout-value="<%= k %>" data-workout-text="<%= text %>"><%= text %></button>
+                    <% end %>
+                  </div>
+                  <div data-workout-selector-target="phaseContainer" class="flex flex-col gap-2 mt-4 hidden">
+                    <% TrainingPlanDay.activity_phases.keys.each do |p| %>
+                      <% text = t("activerecord.attributes.training_plan_day.activity_phases.#{p}") %>
+                      <button type="button" class="btn btn-outline rounded-lg" data-action="click->workout-selector#choosePhase" data-phase-value="<%= p %>" data-phase-text="<%= text %>"><%= text %></button>
                     <% end %>
                   </div>
                 </div>

--- a/app/views/training_plans/new.html.erb
+++ b/app/views/training_plans/new.html.erb
@@ -46,8 +46,8 @@
                 <span data-workout-selector-target="display" class="<%= workout_color_class(day_fields.object.workout_type) %> badge rounded-lg">
                   <%= t("activerecord.attributes.training_plan_day.workout_types.#{day_fields.object.workout_type}") %>
                 </span>
-                <span data-workout-selector-target="phaseDisplay" class="badge badge-outline ml-2">
-                  <%= t("activerecord.attributes.training_plan_day.activity_phases.#{day_fields.object.activity_phase}") %>
+                <span data-workout-selector-target="phaseDisplay" data-segments-target="display" class="badge badge-outline ml-2">
+                  <%= day_fields.object.segments.map { |s| t("activerecord.attributes.training_plan_segment.phases.#{s.phase}") }.join(', ') %>
                 </span>
               </label>
               <input type="checkbox" id="<%= modal_id %>" class="modal-toggle" />
@@ -61,11 +61,26 @@
                       <button type="button" class="btn <%= workout_color_class(k) %> rounded-lg" data-action="click->workout-selector#choose" data-workout-value="<%= k %>" data-workout-text="<%= text %>"><%= text %></button>
                     <% end %>
                   </div>
-                  <div data-workout-selector-target="phaseContainer" class="flex flex-col gap-2 mt-4 hidden">
-                    <% TrainingPlanDay.activity_phases.keys.each do |p| %>
-                      <% text = t("activerecord.attributes.training_plan_day.activity_phases.#{p}") %>
-                      <button type="button" class="btn btn-outline rounded-lg" data-action="click->workout-selector#choosePhase" data-phase-value="<%= p %>" data-phase-text="<%= text %>"><%= text %></button>
-                    <% end %>
+                  <div data-workout-selector-target="phaseContainer" class="flex flex-col gap-2 mt-4 hidden" data-controller="segments" data-segments-target="display">
+                    <div data-segments-target="list">
+                      <%= day_fields.fields_for :segments do |seg_fields| %>
+                        <%= render 'training_plan_days/segment_fields', f: seg_fields %>
+                      <% end %>
+                    </div>
+                    <template data-segments-target="template">
+                      <%= day_fields.fields_for :segments, TrainingPlanSegment.new, child_index: 'NEW_RECORD' do |seg_fields| %>
+                        <%= render 'training_plan_days/segment_fields', f: seg_fields %>
+                      <% end %>
+                    </template>
+                    <div class="flex gap-2 mt-2">
+                      <% TrainingPlanSegment.phases.keys.each do |p| %>
+                        <% text = t("activerecord.attributes.training_plan_segment.phases.#{p}") %>
+                        <button type="button" class="btn btn-outline" data-action="segments#addPhase" data-phase-value="<%= p %>"><%= text %></button>
+                      <% end %>
+                    </div>
+                    <div class="modal-action mt-4">
+                      <label for="<%= modal_id %>" class="btn text-white bg-[#5E81AC] hover:bg-[#4c6b90]">Guardar</label>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/views/training_plans/new.html.erb
+++ b/app/views/training_plans/new.html.erb
@@ -39,8 +39,7 @@
             <% date = @training_plan.date_for(day_fields.object.day) %>
               <div class="form-control mb-4 rounded-lg p-2 <%= workout_color_class(day_fields.object.workout_type) %>" data-controller="workout-selector" data-workout-selector-toggle-id-value="<%= modal_id %>" data-workout-selector-title-value="<%= t('training_plans.select_activity_for', date: "#{TrainingPlanDay::DAYS_OF_WEEK[day_fields.object.day]} #{short_date_es(date)}") %>">
               <%= day_fields.hidden_field :day %>
-              <%= day_fields.hidden_field :workout_type, value: day_fields.object.workout_type, data: { workout_selector_target: 'workoutInput' } %>
-              <%= day_fields.hidden_field :activity_phase, value: day_fields.object.activity_phase, data: { workout_selector_target: 'phaseInput' } %>
+                <%= day_fields.hidden_field :workout_type, value: day_fields.object.workout_type, data: { workout_selector_target: 'workoutInput' } %>
               <label for="<%= modal_id %>" class="label cursor-pointer" data-action="click->workout-selector#open">
                 <span class="label-text"><%= "#{TrainingPlanDay::DAYS_OF_WEEK[day_fields.object.day]} #{short_date_es(date)}" %>:</span>
                 <span data-workout-selector-target="display" class="<%= workout_color_class(day_fields.object.workout_type) %> badge rounded-lg">
@@ -55,37 +54,35 @@
                 <div class="modal-box relative rounded-xl">
                   <label for="<%= modal_id %>" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
                   <h3 class="text-lg font-semibold mb-4" data-workout-selector-target="modalTitle"><%= t('training_plans.select_activity') %></h3>
-                  <div class="flex flex-col gap-2" data-workout-selector-target="workoutContainer">
-                    <% TrainingPlanDay.workout_types.keys.each do |k| %>
-                      <% text = t("activerecord.attributes.training_plan_day.workout_types.#{k}") %>
-                      <button type="button" class="btn <%= workout_color_class(k) %> rounded-lg" data-action="click->workout-selector#choose" data-workout-value="<%= k %>" data-workout-text="<%= text %>"><%= text %></button>
-                    <% end %>
-                  </div>
-                  <div data-workout-selector-target="phaseContainer" class="flex flex-col gap-2 mt-4 hidden" data-controller="segments" data-segments-target="display">
-                    <div data-segments-target="list">
-                      <%= day_fields.fields_for :segments do |seg_fields| %>
-                        <%= render 'training_plan_days/segment_fields', f: seg_fields %>
+                    <div class="flex flex-col gap-2" data-workout-selector-target="workoutContainer">
+                      <% TrainingPlanDay.workout_types.keys.each do |k| %>
+                        <% text = t("activerecord.attributes.training_plan_day.workout_types.#{k}") %>
+                        <button type="button" class="btn <%= workout_color_class(k) %> rounded-lg" data-action="click->workout-selector#choose" data-workout-value="<%= k %>" data-workout-text="<%= text %>"><%= text %></button>
                       <% end %>
                     </div>
-                    <template data-segments-target="template">
-                      <%= day_fields.fields_for :segments, TrainingPlanSegment.new, child_index: 'NEW_RECORD' do |seg_fields| %>
-                        <%= render 'training_plan_days/segment_fields', f: seg_fields %>
-                      <% end %>
-                    </template>
-                    <div class="flex gap-2 mt-2">
-                      <% TrainingPlanSegment.phases.keys.each do |p| %>
-                        <% text = t("activerecord.attributes.training_plan_segment.phases.#{p}") %>
-                        <button type="button" class="btn btn-outline" data-action="segments#addPhase" data-phase-value="<%= p %>"><%= text %></button>
-                      <% end %>
-                    </div>
-                    <div class="modal-action mt-4">
-                      <label for="<%= modal_id %>" class="btn text-white bg-[#5E81AC] hover:bg-[#4c6b90]">Guardar</label>
+                    <div data-workout-selector-target="phaseContainer" class="flex flex-col gap-2 mt-4 hidden" data-controller="segments" data-segments-target="display">
+                      <div class="flex items-center gap-2 mb-2">
+                        <span>Seleccionar ejercicio</span>
+                        <button type="button" class="btn btn-sm btn-outline" data-action="segments#add">+</button>
+                      </div>
+                      <div data-segments-target="list">
+                        <%= day_fields.fields_for :segments do |seg_fields| %>
+                          <%= render 'training_plan_days/segment_fields', f: seg_fields %>
+                        <% end %>
+                      </div>
+                      <template data-segments-target="template">
+                        <%= day_fields.fields_for :segments, TrainingPlanSegment.new, child_index: 'NEW_RECORD' do |seg_fields| %>
+                          <%= render 'training_plan_days/segment_fields', f: seg_fields %>
+                        <% end %>
+                      </template>
+                      <div class="modal-action mt-4">
+                        <label for="<%= modal_id %>" class="btn text-white bg-[#5E81AC] hover:bg-[#4c6b90]">Guardar</label>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
           <div class="flex justify-end">
             <%= f.submit 'Guardar', class: 'btn text-white bg-[#5E81AC] hover:bg-[#4c6b90] border-none' %>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,12 @@ en:
           long_run: "Long run"
           intensity: "Intensidad"
           rest: "Descanso"
+        activity_phases:
+          warm_up: "Calentamiento"
+          workout: "Entrenar"
+          rest: "Descanso"
+          cool_down: "Vuelta a la calma"
+          interval: "Intervalo"
   training_plans:
     select_activity: "Seleccione una actividad"
     select_activity_for: "Seleccione una actividad para %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,26 +31,28 @@ en:
   hello: "Hello world"
   activerecord:
     attributes:
-      training_plan_day:
-        workout_types:
-          strength: "Fuerza"
-          easy_run: "Easy run"
-          long_run: "Long run"
-          intensity: "Intensidad"
-          rest: "Descanso"
-        activity_phases:
-          warm_up: "Calentamiento"
-          workout: "Entrenar"
-          rest: "Descanso"
-          cool_down: "Vuelta a la calma"
-          interval: "Intervalo"
-      training_plan_segment:
-        phases:
-          warm_up: "Calentamiento"
-          workout: "Entrenar"
-          rest: "Descanso"
-          cool_down: "Vuelta a la calma"
-          interval: "Intervalo"
+        training_plan_day:
+          workout_types:
+            strength: "Fuerza"
+            easy_run: "Easy run"
+            long_run: "Long run"
+            intensity: "Intensidad"
+            rest: "Descanso"
+            cross_training: "Cruzado"
+        training_plan_segment:
+          phases:
+            warm_up: "Calentamiento"
+            workout: "Entrenar"
+            rest: "Descanso"
+            cool_down: "Vuelta a la calma"
+          objective_types:
+            distance: "Distancia"
+            time: "Tiempo"
+            heart_rate_zone: "Zona cardiaca"
+            free: "Libre"
+          intensity_types:
+            heart_rate: "Frecuencia cardiaca"
+            rpe: "RPE"
   training_plans:
     select_activity: "Seleccione una actividad"
     select_activity_for: "Seleccione una actividad para %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,13 @@ en:
           rest: "Descanso"
           cool_down: "Vuelta a la calma"
           interval: "Intervalo"
+      training_plan_segment:
+        phases:
+          warm_up: "Calentamiento"
+          workout: "Entrenar"
+          rest: "Descanso"
+          cool_down: "Vuelta a la calma"
+          interval: "Intervalo"
   training_plans:
     select_activity: "Seleccione una actividad"
     select_activity_for: "Seleccione una actividad para %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
             workout: "Entrenar"
             rest: "Descanso"
             cool_down: "Vuelta a la calma"
+            interval: "Intervalo"
           objective_types:
             distance: "Distancia"
             time: "Tiempo"

--- a/db/migrate/20250801000000_add_activity_phase_to_training_plan_days.rb
+++ b/db/migrate/20250801000000_add_activity_phase_to_training_plan_days.rb
@@ -1,0 +1,5 @@
+class AddActivityPhaseToTrainingPlanDays < ActiveRecord::Migration[7.1]
+  def change
+    add_column :training_plan_days, :activity_phase, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20250801000000_add_activity_phase_to_training_plan_days.rb
+++ b/db/migrate/20250801000000_add_activity_phase_to_training_plan_days.rb
@@ -1,5 +1,0 @@
-class AddActivityPhaseToTrainingPlanDays < ActiveRecord::Migration[7.1]
-  def change
-    add_column :training_plan_days, :activity_phase, :integer, null: false, default: 1
-  end
-end

--- a/db/migrate/20250801001000_create_training_plan_segments.rb
+++ b/db/migrate/20250801001000_create_training_plan_segments.rb
@@ -1,0 +1,14 @@
+class CreateTrainingPlanSegments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :training_plan_segments do |t|
+      t.references :training_plan_day, null: false, foreign_key: true
+      t.integer :phase, null: false
+      t.integer :duration
+      t.decimal :distance, precision: 6, scale: 2
+      t.integer :hr_zone
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250801001000_create_training_plan_segments.rb
+++ b/db/migrate/20250801001000_create_training_plan_segments.rb
@@ -2,11 +2,15 @@ class CreateTrainingPlanSegments < ActiveRecord::Migration[7.1]
   def change
     create_table :training_plan_segments do |t|
       t.references :training_plan_day, null: false, foreign_key: true
-      t.integer :phase, null: false
-      t.integer :duration
-      t.decimal :distance, precision: 6, scale: 2
-      t.integer :hr_zone
-      t.integer :position
+        t.integer :phase, null: false
+        t.integer :objective_type, null: false
+        t.integer :duration
+        t.decimal :distance, precision: 6, scale: 2
+        t.integer :hr_zone
+        t.integer :intensity_type
+        t.integer :intensity_from
+        t.integer :intensity_to
+        t.integer :position
 
       t.timestamps
     end


### PR DESCRIPTION
## Summary
- add activity phase enum to `TrainingPlanDay`
- permit new field in controller and initialize with default
- extend locale strings for activity phases
- show phase badge and selection options in the modal
- update JS controller to handle phase selection
- migration for new column

## Testing
- `ruby -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688cf3bc3204832299326ab6ea49a4da